### PR TITLE
feat: Implement 8 JPA repositories for entities

### DIFF
--- a/src/main/java/org/tvl/tvlooker/persistence/repository/ActorRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/ActorRepository.java
@@ -1,0 +1,7 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Actor;
+
+interface ActorRepository extends JpaRepository<Actor, Long> {
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/DirectorRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/DirectorRepository.java
@@ -1,0 +1,7 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Director;
+
+interface DirectorRepository extends JpaRepository<Director, Long> {
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/GenreRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/GenreRepository.java
@@ -1,0 +1,7 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Genre;
+
+interface GenreRepository extends JpaRepository<Genre, Long> {
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/InteractionRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/InteractionRepository.java
@@ -1,0 +1,11 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Interaction;
+
+import java.util.List;
+import java.util.UUID;
+
+interface InteractionRepository extends JpaRepository<Interaction, Long> {
+    List<Interaction> findByUser_Id(UUID userId);
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/InteractionRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/InteractionRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.UUID;
 
 interface InteractionRepository extends JpaRepository<Interaction, Long> {
-    List<Interaction> findByUser_Id(UUID userId);
+    List<Interaction> findByUserId(UUID userId);
 }

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/ItemRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/ItemRepository.java
@@ -1,0 +1,7 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Item;
+
+interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepository.java
@@ -1,12 +1,11 @@
 package org.tvl.tvlooker.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.tvl.tvlooker.domain.model.entity.Interaction;
 import org.tvl.tvlooker.domain.model.entity.ListFavorite;
 
 import java.util.List;
 import java.util.UUID;
 
 interface ListFavoriteRepository extends JpaRepository<ListFavorite, Long> {
-    List<ListFavorite> findByUser_Id(UUID userId);
+    List<ListFavorite> findByUserId(UUID userId);
 }

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepository.java
@@ -1,0 +1,12 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Interaction;
+import org.tvl.tvlooker.domain.model.entity.ListFavorite;
+
+import java.util.List;
+import java.util.UUID;
+
+interface ListFavoriteRepository extends JpaRepository<ListFavorite, Long> {
+    List<ListFavorite> findByUser_Id(UUID userId);
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/ReviewRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/ReviewRepository.java
@@ -1,12 +1,11 @@
 package org.tvl.tvlooker.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.tvl.tvlooker.domain.model.entity.Interaction;
 import org.tvl.tvlooker.domain.model.entity.Review;
 
 import java.util.List;
 import java.util.UUID;
 
 interface ReviewRepository extends JpaRepository<Review, Long> {
-    List<Review> findByUser_Id(UUID userId);
+    List<Review> findByUserId(UUID userId);
 }

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/ReviewRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/ReviewRepository.java
@@ -1,0 +1,12 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.Interaction;
+import org.tvl.tvlooker.domain.model.entity.Review;
+
+import java.util.List;
+import java.util.UUID;
+
+interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByUser_Id(UUID userId);
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/UserRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tvl.tvlooker.domain.model.entity.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+interface UserRepository extends JpaRepository<User, UUID> {
+}

--- a/src/main/java/org/tvl/tvlooker/persistence/repository/UserRepository.java
+++ b/src/main/java/org/tvl/tvlooker/persistence/repository/UserRepository.java
@@ -3,7 +3,6 @@ package org.tvl.tvlooker.persistence.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.tvl.tvlooker.domain.model.entity.User;
 
-import java.util.Optional;
 import java.util.UUID;
 
 interface UserRepository extends JpaRepository<User, UUID> {

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/ActorRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/ActorRepositoryTest.java
@@ -1,0 +1,232 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Actor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for ActorRepository.
+ * Tests cover CRUD operations and unique constraints.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("ActorRepository TDD Tests")
+class ActorRepositoryTest {
+
+    @Autowired
+    private ActorRepository actorRepository;
+
+    @AfterEach
+    void tearDown() {
+        actorRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new actor")
+    void testSaveActor() {
+        // Given
+        Actor actor = createActor(1L, "John Doe");
+
+        // When
+        Actor savedActor = actorRepository.saveAndFlush(actor);
+
+        // Then
+        assertThat(savedActor).isNotNull();
+        assertThat(savedActor.getId()).isNotNull();
+        assertThat(savedActor.getName()).isEqualTo("John Doe");
+        assertThat(savedActor.getTmdbId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("Should save multiple actors")
+    void testSaveMultipleActors() {
+        // Given
+        Actor actor1 = createActor(1L, "Actor One");
+        Actor actor2 = createActor(2L, "Actor Two");
+        Actor actor3 = createActor(3L, "Actor Three");
+
+        // When
+        List<Actor> savedActors = actorRepository.saveAll(List.of(actor1, actor2, actor3));
+
+        // Then
+        assertThat(savedActors).hasSize(3);
+        assertThat(actorRepository.count()).isEqualTo(3);
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find actor by ID")
+    void testFindById() {
+        // Given
+        Actor actor = createActor(100L, "Jane Smith");
+        Actor savedActor = actorRepository.saveAndFlush(actor);
+
+        // When
+        Optional<Actor> foundActor = actorRepository.findById(savedActor.getId());
+
+        // Then
+        assertThat(foundActor).isPresent();
+        assertThat(foundActor.get().getName()).isEqualTo("Jane Smith");
+    }
+
+    @Test
+    @DisplayName("Should find all actors")
+    void testFindAll() {
+        // Given
+        actorRepository.saveAll(List.of(
+                createActor(1L, "Actor One"),
+                createActor(2L, "Actor Two"),
+                createActor(3L, "Actor Three")
+        ));
+
+        // When
+        List<Actor> allActors = actorRepository.findAll();
+
+        // Then
+        assertThat(allActors).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should count all actors")
+    void testCount() {
+        // Given
+        actorRepository.saveAll(List.of(
+                createActor(1L, "Actor One"),
+                createActor(2L, "Actor Two")
+        ));
+
+        // When
+        long count = actorRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update actor name")
+    void testUpdateActor() {
+        // Given
+        Actor actor = createActor(1L, "Old Name");
+        Actor savedActor = actorRepository.saveAndFlush(actor);
+
+        // When
+        savedActor.setName("New Name");
+        Actor updatedActor = actorRepository.saveAndFlush(savedActor);
+
+        // Then
+        assertThat(updatedActor.getId()).isEqualTo(savedActor.getId());
+        assertThat(updatedActor.getName()).isEqualTo("New Name");
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete actor by ID")
+    void testDeleteById() {
+        // Given
+        Actor actor = createActor(1L, "To Delete");
+        Actor savedActor = actorRepository.saveAndFlush(actor);
+
+        // When
+        actorRepository.deleteById(savedActor.getId());
+
+        // Then
+        assertThat(actorRepository.findById(savedActor.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all actors")
+    void testDeleteAll() {
+        // Given
+        actorRepository.saveAll(List.of(
+                createActor(1L, "Actor One"),
+                createActor(2L, "Actor Two")
+        ));
+
+        // When
+        actorRepository.deleteAll();
+
+        // Then
+        assertThat(actorRepository.count()).isZero();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should not allow null name")
+    void testNullName() {
+        // Given
+        Actor actor = createActor(1L, null);
+
+        // When & Then
+        try {
+            actorRepository.saveAndFlush(actor);
+            fail("Should have thrown exception for null name");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null tmdbId")
+    void testNullTmdbId() {
+        // Given
+        Actor actor = new Actor();
+        actor.setName("Test Actor");
+        actor.setTmdbId(null);
+
+        // When & Then
+        try {
+            actorRepository.saveAndFlush(actor);
+            fail("Should have thrown exception for null tmdbId");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should enforce unique tmdbId constraint")
+    void testUniqueTmdbId() {
+        // Given
+        Actor actor1 = createActor(1L, "Actor One");
+        actorRepository.saveAndFlush(actor1);
+
+        Actor actor2 = createActor(1L, "Actor Two");
+
+        // When & Then
+        try {
+            actorRepository.saveAndFlush(actor2);
+            fail("Should have thrown exception for duplicate tmdbId");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private Actor createActor(Long tmdbId, String name) {
+        Actor actor = new Actor();
+        actor.setTmdbId(tmdbId);
+        actor.setName(name);
+        return actor;
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/DirectorRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/DirectorRepositoryTest.java
@@ -1,0 +1,232 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Director;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for DirectorRepository.
+ * Tests cover CRUD operations and unique constraints.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("DirectorRepository TDD Tests")
+class DirectorRepositoryTest {
+
+    @Autowired
+    private DirectorRepository directorRepository;
+
+    @AfterEach
+    void tearDown() {
+        directorRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new director")
+    void testSaveDirector() {
+        // Given
+        Director director = createDirector(1L, "Christopher Nolan");
+
+        // When
+        Director savedDirector = directorRepository.saveAndFlush(director);
+
+        // Then
+        assertThat(savedDirector).isNotNull();
+        assertThat(savedDirector.getId()).isNotNull();
+        assertThat(savedDirector.getName()).isEqualTo("Christopher Nolan");
+        assertThat(savedDirector.getTmdbId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("Should save multiple directors")
+    void testSaveMultipleDirectors() {
+        // Given
+        Director director1 = createDirector(1L, "Director One");
+        Director director2 = createDirector(2L, "Director Two");
+        Director director3 = createDirector(3L, "Director Three");
+
+        // When
+        List<Director> savedDirectors = directorRepository.saveAll(List.of(director1, director2, director3));
+
+        // Then
+        assertThat(savedDirectors).hasSize(3);
+        assertThat(directorRepository.count()).isEqualTo(3);
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find director by ID")
+    void testFindById() {
+        // Given
+        Director director = createDirector(100L, "Steven Spielberg");
+        Director savedDirector = directorRepository.saveAndFlush(director);
+
+        // When
+        Optional<Director> foundDirector = directorRepository.findById(savedDirector.getId());
+
+        // Then
+        assertThat(foundDirector).isPresent();
+        assertThat(foundDirector.get().getName()).isEqualTo("Steven Spielberg");
+    }
+
+    @Test
+    @DisplayName("Should find all directors")
+    void testFindAll() {
+        // Given
+        directorRepository.saveAll(List.of(
+                createDirector(1L, "Director One"),
+                createDirector(2L, "Director Two"),
+                createDirector(3L, "Director Three")
+        ));
+
+        // When
+        List<Director> allDirectors = directorRepository.findAll();
+
+        // Then
+        assertThat(allDirectors).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should count all directors")
+    void testCount() {
+        // Given
+        directorRepository.saveAll(List.of(
+                createDirector(1L, "Director One"),
+                createDirector(2L, "Director Two")
+        ));
+
+        // When
+        long count = directorRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update director name")
+    void testUpdateDirector() {
+        // Given
+        Director director = createDirector(1L, "Old Name");
+        Director savedDirector = directorRepository.saveAndFlush(director);
+
+        // When
+        savedDirector.setName("New Name");
+        Director updatedDirector = directorRepository.saveAndFlush(savedDirector);
+
+        // Then
+        assertThat(updatedDirector.getId()).isEqualTo(savedDirector.getId());
+        assertThat(updatedDirector.getName()).isEqualTo("New Name");
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete director by ID")
+    void testDeleteById() {
+        // Given
+        Director director = createDirector(1L, "To Delete");
+        Director savedDirector = directorRepository.saveAndFlush(director);
+
+        // When
+        directorRepository.deleteById(savedDirector.getId());
+
+        // Then
+        assertThat(directorRepository.findById(savedDirector.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all directors")
+    void testDeleteAll() {
+        // Given
+        directorRepository.saveAll(List.of(
+                createDirector(1L, "Director One"),
+                createDirector(2L, "Director Two")
+        ));
+
+        // When
+        directorRepository.deleteAll();
+
+        // Then
+        assertThat(directorRepository.count()).isZero();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should not allow null name")
+    void testNullName() {
+        // Given
+        Director director = createDirector(1L, null);
+
+        // When & Then
+        try {
+            directorRepository.saveAndFlush(director);
+            fail("Should have thrown exception for null name");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null tmdbId")
+    void testNullTmdbId() {
+        // Given
+        Director director = new Director();
+        director.setName("Test Director");
+        director.setTmdbId(null);
+
+        // When & Then
+        try {
+            directorRepository.saveAndFlush(director);
+            fail("Should have thrown exception for null tmdbId");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should enforce unique tmdbId constraint")
+    void testUniqueTmdbId() {
+        // Given
+        Director director1 = createDirector(1L, "Director One");
+        directorRepository.saveAndFlush(director1);
+
+        Director director2 = createDirector(1L, "Director Two");
+
+        // When & Then
+        try {
+            directorRepository.saveAndFlush(director2);
+            fail("Should have thrown exception for duplicate tmdbId");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private Director createDirector(Long tmdbId, String name) {
+        Director director = new Director();
+        director.setTmdbId(tmdbId);
+        director.setName(name);
+        return director;
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/GenreRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/GenreRepositoryTest.java
@@ -1,0 +1,196 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Genre;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for GenreRepository.
+ * Tests cover CRUD operations.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("GenreRepository TDD Tests")
+class GenreRepositoryTest {
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @AfterEach
+    void tearDown() {
+        genreRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new genre")
+    void testSaveGenre() {
+        // Given
+        Genre genre = createGenre("Action");
+
+        // When
+        Genre savedGenre = genreRepository.saveAndFlush(genre);
+
+        // Then
+        assertThat(savedGenre).isNotNull();
+        assertThat(savedGenre.getId()).isNotNull();
+        assertThat(savedGenre.getName()).isEqualTo("Action");
+    }
+
+    @Test
+    @DisplayName("Should save multiple genres")
+    void testSaveMultipleGenres() {
+        // Given
+        Genre genre1 = createGenre("Action");
+        Genre genre2 = createGenre("Comedy");
+        Genre genre3 = createGenre("Drama");
+
+        // When
+        List<Genre> savedGenres = genreRepository.saveAll(List.of(genre1, genre2, genre3));
+
+        // Then
+        assertThat(savedGenres).hasSize(3);
+        assertThat(genreRepository.count()).isEqualTo(3);
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find genre by ID")
+    void testFindById() {
+        // Given
+        Genre genre = createGenre("Sci-Fi");
+        Genre savedGenre = genreRepository.saveAndFlush(genre);
+
+        // When
+        Optional<Genre> foundGenre = genreRepository.findById(savedGenre.getId());
+
+        // Then
+        assertThat(foundGenre).isPresent();
+        assertThat(foundGenre.get().getName()).isEqualTo("Sci-Fi");
+    }
+
+    @Test
+    @DisplayName("Should find all genres")
+    void testFindAll() {
+        // Given
+        genreRepository.saveAll(List.of(
+                createGenre("Action"),
+                createGenre("Comedy"),
+                createGenre("Drama")
+        ));
+
+        // When
+        List<Genre> allGenres = genreRepository.findAll();
+
+        // Then
+        assertThat(allGenres).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should count all genres")
+    void testCount() {
+        // Given
+        genreRepository.saveAll(List.of(
+                createGenre("Action"),
+                createGenre("Comedy")
+        ));
+
+        // When
+        long count = genreRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update genre name")
+    void testUpdateGenre() {
+        // Given
+        Genre genre = createGenre("Old Name");
+        Genre savedGenre = genreRepository.saveAndFlush(genre);
+
+        // When
+        savedGenre.setName("New Name");
+        Genre updatedGenre = genreRepository.saveAndFlush(savedGenre);
+
+        // Then
+        assertThat(updatedGenre.getId()).isEqualTo(savedGenre.getId());
+        assertThat(updatedGenre.getName()).isEqualTo("New Name");
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete genre by ID")
+    void testDeleteById() {
+        // Given
+        Genre genre = createGenre("To Delete");
+        Genre savedGenre = genreRepository.saveAndFlush(genre);
+
+        // When
+        genreRepository.deleteById(savedGenre.getId());
+
+        // Then
+        assertThat(genreRepository.findById(savedGenre.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all genres")
+    void testDeleteAll() {
+        // Given
+        genreRepository.saveAll(List.of(
+                createGenre("Action"),
+                createGenre("Comedy")
+        ));
+
+        // When
+        genreRepository.deleteAll();
+
+        // Then
+        assertThat(genreRepository.count()).isZero();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should not allow null name")
+    void testNullName() {
+        // Given
+        Genre genre = new Genre();
+        genre.setName(null);
+
+        // When & Then
+        try {
+            genreRepository.saveAndFlush(genre);
+            fail("Should have thrown exception for null name");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private Genre createGenre(String name) {
+        Genre genre = new Genre();
+        genre.setName(name);
+        return genre;
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/InteractionRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/InteractionRepositoryTest.java
@@ -1,0 +1,456 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Interaction;
+import org.tvl.tvlooker.domain.model.entity.Item;
+import org.tvl.tvlooker.domain.model.entity.Review;
+import org.tvl.tvlooker.domain.model.entity.User;
+import org.tvl.tvlooker.domain.model.enums.InteractionType;
+import org.tvl.tvlooker.domain.model.enums.TmdbType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TDD Test class for InteractionRepository.
+ * Tests cover CRUD operations, custom queries, and relationships.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("InteractionRepository TDD Tests")
+class InteractionRepositoryTest {
+
+    @Autowired
+    private InteractionRepository interactionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @AfterEach
+    void tearDown() {
+        interactionRepository.deleteAll();
+        reviewRepository.deleteAll();
+        itemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new interaction")
+    void testSaveInteraction() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item = createAndSaveItem(1L, "Movie 1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.VIEW)
+                .user(user)
+                .item(item)
+                .build();
+
+        // When
+        Interaction savedInteraction = interactionRepository.save(interaction);
+
+        // Then
+        assertThat(savedInteraction).isNotNull();
+        assertThat(savedInteraction.getId()).isEqualTo(1L);
+        assertThat(savedInteraction.getInteractionType()).isEqualTo(InteractionType.VIEW);
+    }
+
+    @Test
+    @DisplayName("Should save interaction with review")
+    void testSaveInteractionWithReview() {
+        // Given - Create user and item WITHOUT saving (Review has cascade persist on item)
+        User user = createUser("user1");
+        Item item = createItem(1L, "Movie 1");
+
+        // Create and save Review - this will cascade persist user and item
+        Review review = Review.builder()
+                .reviewText("Great movie!")
+                .score(8)
+                .item(item)
+                .user(user)
+                .build();
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // Refresh to get managed entities
+        User savedUser = userRepository.findById(user.getId()).orElseThrow();
+        Item savedItem = itemRepository.findById(item.getId()).orElseThrow();
+
+        Interaction interaction = Interaction.builder()
+                .id(2L)
+                .interactionType(InteractionType.REVIEW)
+                .user(savedUser)
+                .item(savedItem)
+                .review(savedReview)
+                .build();
+
+        // When
+        Interaction savedInteraction = interactionRepository.save(interaction);
+
+        // Then
+        assertThat(savedInteraction).isNotNull();
+        assertThat(savedInteraction.getInteractionType()).isEqualTo(InteractionType.REVIEW);
+        assertThat(savedInteraction.getReview()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should save multiple interactions")
+    void testSaveMultipleInteractions() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item1 = createAndSaveItem(1L, "Movie 1");
+        Item item2 = createAndSaveItem(2L, "Movie 2");
+
+        Interaction interaction1 = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.VIEW)
+                .user(user)
+                .item(item1)
+                .build();
+
+        Interaction interaction2 = Interaction.builder()
+                .id(2L)
+                .interactionType(InteractionType.LIKE)
+                .user(user)
+                .item(item2)
+                .build();
+
+        // When
+        List<Interaction> savedInteractions = interactionRepository.saveAll(List.of(interaction1, interaction2));
+
+        // Then
+        assertThat(savedInteractions).hasSize(2);
+        assertThat(interactionRepository.count()).isEqualTo(2);
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find interaction by ID")
+    void testFindById() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item = createAndSaveItem(1L, "Movie 1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.CLICK)
+                .user(user)
+                .item(item)
+                .build();
+        Interaction savedInteraction = interactionRepository.save(interaction);
+
+        // When
+        Optional<Interaction> foundInteraction = interactionRepository.findById(1L);
+
+        // Then
+        assertThat(foundInteraction).isPresent();
+        assertThat(foundInteraction.get().getInteractionType()).isEqualTo(InteractionType.CLICK);
+    }
+
+    @Test
+    @DisplayName("Should find all interactions")
+    void testFindAll() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item1 = createAndSaveItem(1L, "Movie 1");
+        Item item2 = createAndSaveItem(2L, "Movie 2");
+
+        interactionRepository.saveAll(List.of(
+                Interaction.builder().id(1L).interactionType(InteractionType.VIEW).user(user).item(item1).build(),
+                Interaction.builder().id(2L).interactionType(InteractionType.LIKE).user(user).item(item2).build()
+        ));
+
+        // When
+        List<Interaction> allInteractions = interactionRepository.findAll();
+
+        // Then
+        assertThat(allInteractions).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Should count all interactions")
+    void testCount() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item1 = createAndSaveItem(1L, "Movie 1");
+        Item item2 = createAndSaveItem(2L, "Movie 2");
+
+        interactionRepository.saveAll(List.of(
+                Interaction.builder().id(1L).interactionType(InteractionType.VIEW).user(user).item(item1).build(),
+                Interaction.builder().id(2L).interactionType(InteractionType.RATING).user(user).item(item2).build()
+        ));
+
+        // When
+        long count = interactionRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== CUSTOM QUERY TESTS ====================
+
+    @Test
+    @DisplayName("Should find interactions by user ID")
+    void testFindByUserId() {
+        // Given
+        User user1 = createAndSaveUser("user1");
+        User user2 = createAndSaveUser("user2");
+        Item item1 = createAndSaveItem(1L, "Movie 1");
+        Item item2 = createAndSaveItem(2L, "Movie 2");
+        Item item3 = createAndSaveItem(3L, "Movie 3");
+
+        interactionRepository.saveAll(List.of(
+                Interaction.builder().id(1L).interactionType(InteractionType.VIEW).user(user1).item(item1).build(),
+                Interaction.builder().id(2L).interactionType(InteractionType.LIKE).user(user1).item(item2).build(),
+                Interaction.builder().id(3L).interactionType(InteractionType.CLICK).user(user2).item(item3).build()
+        ));
+
+        // When
+        List<Interaction> user1Interactions = interactionRepository.findByUser_Id(user1.getId());
+        List<Interaction> user2Interactions = interactionRepository.findByUser_Id(user2.getId());
+
+        // Then
+        assertThat(user1Interactions).hasSize(2);
+        assertThat(user2Interactions).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when user has no interactions")
+    void testFindByUserIdNoInteractions() {
+        // Given
+        User user = createAndSaveUser("user1");
+
+        // When
+        List<Interaction> interactions = interactionRepository.findByUser_Id(user.getId());
+
+        // Then
+        assertThat(interactions).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should return empty list for non-existent user ID")
+    void testFindByUserIdNotFound() {
+        // Given
+        UUID nonExistentUserId = UUID.randomUUID();
+
+        // When
+        List<Interaction> interactions = interactionRepository.findByUser_Id(nonExistentUserId);
+
+        // Then
+        assertThat(interactions).isEmpty();
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update interaction type")
+    void testUpdateInteraction() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item = createAndSaveItem(1L, "Movie 1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.VIEW)
+                .user(user)
+                .item(item)
+                .build();
+        Interaction savedInteraction = interactionRepository.save(interaction);
+
+        // When
+        savedInteraction.setInteractionType(InteractionType.RESEARCH);
+        Interaction updatedInteraction = interactionRepository.save(savedInteraction);
+
+        // Then
+        assertThat(updatedInteraction.getId()).isEqualTo(1L);
+        assertThat(updatedInteraction.getInteractionType()).isEqualTo(InteractionType.RESEARCH);
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete interaction by ID")
+    void testDeleteById() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item = createAndSaveItem(1L, "Movie 1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.VIEW)
+                .user(user)
+                .item(item)
+                .build();
+        interactionRepository.save(interaction);
+
+        // When
+        interactionRepository.deleteById(1L);
+
+        // Then
+        assertThat(interactionRepository.findById(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all interactions")
+    void testDeleteAll() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item1 = createAndSaveItem(1L, "Movie 1");
+        Item item2 = createAndSaveItem(2L, "Movie 2");
+
+        interactionRepository.saveAll(List.of(
+                Interaction.builder().id(1L).interactionType(InteractionType.VIEW).user(user).item(item1).build(),
+                Interaction.builder().id(2L).interactionType(InteractionType.LIKE).user(user).item(item2).build()
+        ));
+
+        // When
+        interactionRepository.deleteAll();
+
+        // Then
+        assertThat(interactionRepository.count()).isZero();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should not allow null user")
+    void testNullUser() {
+        // Given
+        Item item = createAndSaveItem(1L, "Movie 1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.VIEW)
+                .user(null)
+                .item(item)
+                .build();
+
+        // When & Then
+        try {
+            interactionRepository.save(interaction);
+            Assertions.fail("Should have thrown exception for null user");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null item")
+    void testNullItem() {
+        // Given
+        User user = createAndSaveUser("user1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(InteractionType.VIEW)
+                .user(user)
+                .item(null)
+                .build();
+
+        // When & Then
+        try {
+            interactionRepository.save(interaction);
+            Assertions.fail("Should have thrown exception for null item");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null interaction type")
+    void testNullInteractionType() {
+        // Given
+        User user = createAndSaveUser("user1");
+        Item item = createAndSaveItem(1L, "Movie 1");
+
+        Interaction interaction = Interaction.builder()
+                .id(1L)
+                .interactionType(null)
+                .user(user)
+                .item(item)
+                .build();
+
+        // When & Then
+        try {
+            interactionRepository.save(interaction);
+            Assertions.fail("Should have thrown exception for null interaction type");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private User createAndSaveUser(String username) {
+        User user = User.builder()
+                .username(username)
+                .password("password123")
+                .build();
+        return userRepository.saveAndFlush(user);
+    }
+
+    private Item createAndSaveItem(Long tmdbId, String title) {
+        Item item = Item.builder()
+                .tmdbId(tmdbId)
+                .tmdbType(TmdbType.MOVIE)
+                .title(title)
+                .overview("Overview for " + title)
+                .releaseDate(LocalDate.now())
+                .popularity(new BigDecimal("100.0000"))
+                .voteAverage(new BigDecimal("7.50"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+        return itemRepository.saveAndFlush(item);
+    }
+
+    private User createUser(String username) {
+        return User.builder()
+                .username(username)
+                .password("password123")
+                .build();
+    }
+
+    private Item createItem(Long tmdbId, String title) {
+        return Item.builder()
+                .tmdbId(tmdbId)
+                .tmdbType(TmdbType.MOVIE)
+                .title(title)
+                .overview("Overview for " + title)
+                .releaseDate(LocalDate.now())
+                .popularity(new BigDecimal("100.0000"))
+                .voteAverage(new BigDecimal("7.50"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/InteractionRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/InteractionRepositoryTest.java
@@ -233,8 +233,8 @@ class InteractionRepositoryTest {
         ));
 
         // When
-        List<Interaction> user1Interactions = interactionRepository.findByUser_Id(user1.getId());
-        List<Interaction> user2Interactions = interactionRepository.findByUser_Id(user2.getId());
+        List<Interaction> user1Interactions = interactionRepository.findByUserId(user1.getId());
+        List<Interaction> user2Interactions = interactionRepository.findByUserId(user2.getId());
 
         // Then
         assertThat(user1Interactions).hasSize(2);
@@ -248,7 +248,7 @@ class InteractionRepositoryTest {
         User user = createAndSaveUser("user1");
 
         // When
-        List<Interaction> interactions = interactionRepository.findByUser_Id(user.getId());
+        List<Interaction> interactions = interactionRepository.findByUserId(user.getId());
 
         // Then
         assertThat(interactions).isEmpty();
@@ -261,7 +261,7 @@ class InteractionRepositoryTest {
         UUID nonExistentUserId = UUID.randomUUID();
 
         // When
-        List<Interaction> interactions = interactionRepository.findByUser_Id(nonExistentUserId);
+        List<Interaction> interactions = interactionRepository.findByUserId(nonExistentUserId);
 
         // Then
         assertThat(interactions).isEmpty();

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/ItemRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/ItemRepositoryTest.java
@@ -1,0 +1,484 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Actor;
+import org.tvl.tvlooker.domain.model.entity.Director;
+import org.tvl.tvlooker.domain.model.entity.Genre;
+import org.tvl.tvlooker.domain.model.entity.Item;
+import org.tvl.tvlooker.domain.model.enums.TmdbType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for ItemRepository.
+ * Tests cover CRUD operations, relationships, and constraints.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("ItemRepository TDD Tests")
+class ItemRepositoryTest {
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @Autowired
+    private DirectorRepository directorRepository;
+
+    @Autowired
+    private ActorRepository actorRepository;
+
+    @AfterEach
+    void tearDown() {
+        itemRepository.deleteAll();
+        genreRepository.deleteAll();
+        directorRepository.deleteAll();
+        actorRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new movie item")
+    void testSaveMovieItem() {
+        // Given
+        Item item = Item.builder()
+                .tmdbId(12345L)
+                .tmdbType(TmdbType.MOVIE)
+                .title("The Matrix")
+                .overview("A computer hacker learns about reality")
+                .releaseDate(LocalDate.of(1999, 3, 31))
+                .popularity(new BigDecimal("850.1234"))
+                .voteAverage(new BigDecimal("8.71"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // Then
+        assertThat(savedItem).isNotNull();
+        assertThat(savedItem.getId()).isNotNull();
+        assertThat(savedItem.getTmdbId()).isEqualTo(12345L);
+        assertThat(savedItem.getTmdbType()).isEqualTo(TmdbType.MOVIE);
+        assertThat(savedItem.getTitle()).isEqualTo("The Matrix");
+        assertThat(savedItem.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should save a new TV show item")
+    void testSaveTvShowItem() {
+        // Given
+        Item item = Item.builder()
+                .tmdbId(67890L)
+                .tmdbType(TmdbType.TV)
+                .title("Breaking Bad")
+                .overview("A chemistry teacher turns to cooking meth")
+                .releaseDate(LocalDate.of(2008, 1, 20))
+                .popularity(new BigDecimal("950.5678"))
+                .voteAverage(new BigDecimal("9.50"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // Then
+        assertThat(savedItem).isNotNull();
+        assertThat(savedItem.getTmdbType()).isEqualTo(TmdbType.TV);
+        assertThat(savedItem.getTitle()).isEqualTo("Breaking Bad");
+    }
+
+    @Test
+    @DisplayName("Should save multiple items")
+    void testSaveMultipleItems() {
+        // Given
+        Item item1 = createItem(1L, "Movie 1", TmdbType.MOVIE);
+        Item item2 = createItem(2L, "Movie 2", TmdbType.MOVIE);
+        Item item3 = createItem(3L, "TV Show 1", TmdbType.TV);
+
+        // When
+        List<Item> savedItems = itemRepository.saveAll(List.of(item1, item2, item3));
+
+        // Then
+        assertThat(savedItems).hasSize(3);
+        assertThat(savedItems).extracting(Item::getTitle)
+                .containsExactlyInAnyOrder("Movie 1", "Movie 2", "TV Show 1");
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find item by ID")
+    void testFindById() {
+        // Given
+        Item item = createItem(100L, "Findable Movie", TmdbType.MOVIE);
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // When
+        Optional<Item> foundItem = itemRepository.findById(savedItem.getId());
+
+        // Then
+        assertThat(foundItem).isPresent();
+        assertThat(foundItem.get().getTitle()).isEqualTo("Findable Movie");
+    }
+
+    @Test
+    @DisplayName("Should return empty when item ID not found")
+    void testFindByIdNotFound() {
+        // Given
+        Long nonExistentId = 999999L;
+
+        // When
+        Optional<Item> foundItem = itemRepository.findById(nonExistentId);
+
+        // Then
+        assertThat(foundItem).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should find all items")
+    void testFindAll() {
+        // Given
+        itemRepository.saveAll(List.of(
+                createItem(1L, "Item 1", TmdbType.MOVIE),
+                createItem(2L, "Item 2", TmdbType.TV),
+                createItem(3L, "Item 3", TmdbType.MOVIE)
+        ));
+
+        // When
+        List<Item> allItems = itemRepository.findAll();
+
+        // Then
+        assertThat(allItems).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should check if item exists by ID")
+    void testExistsById() {
+        // Given
+        Item item = createItem(200L, "Existing Item", TmdbType.MOVIE);
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // When
+        boolean exists = itemRepository.existsById(savedItem.getId());
+        boolean notExists = itemRepository.existsById(999999L);
+
+        // Then
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should count all items")
+    void testCount() {
+        // Given
+        itemRepository.saveAll(List.of(
+                createItem(1L, "Item 1", TmdbType.MOVIE),
+                createItem(2L, "Item 2", TmdbType.TV)
+        ));
+
+        // When
+        long count = itemRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update existing item")
+    void testUpdateItem() {
+        // Given
+        Item item = createItem(300L, "Original Title", TmdbType.MOVIE);
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // When
+        savedItem.setTitle("Updated Title");
+        savedItem.setPopularity(new BigDecimal("999.9999"));
+        Item updatedItem = itemRepository.saveAndFlush(savedItem);
+
+        // Then
+        assertThat(updatedItem.getId()).isEqualTo(savedItem.getId());
+        assertThat(updatedItem.getTitle()).isEqualTo("Updated Title");
+        assertThat(updatedItem.getPopularity()).isEqualByComparingTo(new BigDecimal("999.9999"));
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete item by ID")
+    void testDeleteById() {
+        // Given
+        Item item = createItem(400L, "Deletable Item", TmdbType.MOVIE);
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // When
+        itemRepository.deleteById(savedItem.getId());
+
+        // Then
+        assertThat(itemRepository.findById(savedItem.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete item entity")
+    void testDelete() {
+        // Given
+        Item item = createItem(500L, "Delete Me", TmdbType.MOVIE);
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // When
+        itemRepository.delete(savedItem);
+
+        // Then
+        assertThat(itemRepository.findById(savedItem.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all items")
+    void testDeleteAll() {
+        // Given
+        itemRepository.saveAll(List.of(
+                createItem(1L, "Item 1", TmdbType.MOVIE),
+                createItem(2L, "Item 2", TmdbType.TV)
+        ));
+
+        // When
+        itemRepository.deleteAll();
+
+        // Then
+        assertThat(itemRepository.count()).isZero();
+    }
+
+    // ==================== RELATIONSHIP TESTS ====================
+    // Note: These tests demonstrate that items can be saved with relationships.
+    // The CASCADE.PERSIST configuration requires careful entity state management.
+
+    @Test
+    @DisplayName("Should save item with genres using cascade persist")
+    void testSaveItemWithGenres() {
+        // Given - Create new genres (not persisted yet)
+        Genre action = new Genre();
+        action.setName("Action");
+        Genre sciFi = new Genre();
+        sciFi.setName("Sci-Fi");
+
+        Set<Genre> genres = new HashSet<>(List.of(action, sciFi));
+
+        Item item = Item.builder()
+                .tmdbId(600L)
+                .tmdbType(TmdbType.MOVIE)
+                .title("Action Sci-Fi Movie")
+                .genres(genres)
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When - Item save will cascade to genres
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // Then
+        assertThat(savedItem.getGenres()).hasSize(2);
+        assertThat(savedItem.getGenres()).extracting(Genre::getName)
+                .containsExactlyInAnyOrder("Action", "Sci-Fi");
+        // Verify genres were persisted
+        assertThat(genreRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Should save item with directors using cascade persist")
+    void testSaveItemWithDirectors() {
+        // Given - Create new directors (not persisted yet)
+        Director director1 = new Director();
+        director1.setName("Christopher Nolan");
+        director1.setTmdbId(1000L);
+        Director director2 = new Director();
+        director2.setName("Steven Spielberg");
+        director2.setTmdbId(2000L);
+
+        Set<Director> directors = new HashSet<>(List.of(director1, director2));
+
+        Item item = Item.builder()
+                .tmdbId(700L)
+                .tmdbType(TmdbType.MOVIE)
+                .title("Epic Movie")
+                .directors(directors)
+                .genres(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When - Item save will cascade to directors
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // Then
+        assertThat(savedItem.getDirectors()).hasSize(2);
+        assertThat(savedItem.getDirectors()).extracting(Director::getName)
+                .containsExactlyInAnyOrder("Christopher Nolan", "Steven Spielberg");
+        // Verify directors were persisted
+        assertThat(directorRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Should save item with actors using cascade persist")
+    void testSaveItemWithActors() {
+        // Given - Create new actors (not persisted yet)
+        Actor actor1 = new Actor();
+        actor1.setName("Leonardo DiCaprio");
+        actor1.setTmdbId(3000L);
+        Actor actor2 = new Actor();
+        actor2.setName("Tom Hanks");
+        actor2.setTmdbId(4000L);
+
+        Set<Actor> actors = new HashSet<>(List.of(actor1, actor2));
+
+        Item item = Item.builder()
+                .tmdbId(800L)
+                .tmdbType(TmdbType.MOVIE)
+                .title("Star-Studded Film")
+                .actors(actors)
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .build();
+
+        // When - Item save will cascade to actors
+        Item savedItem = itemRepository.saveAndFlush(item);
+
+        // Then
+        assertThat(savedItem.getActors()).hasSize(2);
+        assertThat(savedItem.getActors()).extracting(Actor::getName)
+                .containsExactlyInAnyOrder("Leonardo DiCaprio", "Tom Hanks");
+        // Verify actors were persisted
+        assertThat(actorRepository.count()).isEqualTo(2);
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should enforce tmdbId uniqueness constraint")
+    void testTmdbIdUniqueConstraint() {
+        // Given
+        Item item1 = createItem(9999L, "First Movie", TmdbType.MOVIE);
+        itemRepository.saveAndFlush(item1);
+
+        Item item2 = createItem(9999L, "Duplicate TMDB ID", TmdbType.MOVIE);
+
+        // When & Then
+        try {
+            itemRepository.saveAndFlush(item2);
+            fail("Should have thrown exception for duplicate tmdbId");
+        } catch (Exception e) {
+            // Expected exception due to unique constraint violation
+            assertThat(e.getMessage()).containsAnyOf("unique", "constraint", "duplicate", "Unique");
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null tmdbId")
+    void testNullTmdbId() {
+        // Given
+        Item item = Item.builder()
+                .tmdbId(null)
+                .tmdbType(TmdbType.MOVIE)
+                .title("Invalid Item")
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When & Then
+        try {
+            itemRepository.saveAndFlush(item);
+            fail("Should have thrown exception for null tmdbId");
+        } catch (Exception e) {
+            // Expected exception due to null constraint violation
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null tmdbType")
+    void testNullTmdbType() {
+        // Given
+        Item item = Item.builder()
+                .tmdbId(10000L)
+                .tmdbType(null)
+                .title("Invalid Type Item")
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When & Then
+        try {
+            itemRepository.saveAndFlush(item);
+            fail("Should have thrown exception for null tmdbType");
+        } catch (Exception e) {
+            // Expected exception due to null constraint violation
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null title")
+    void testNullTitle() {
+        // Given
+        Item item = Item.builder()
+                .tmdbId(10001L)
+                .tmdbType(TmdbType.MOVIE)
+                .title(null)
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+
+        // When & Then
+        try {
+            itemRepository.saveAndFlush(item);
+            fail("Should have thrown exception for null title");
+        } catch (Exception e) {
+            // Expected exception due to null constraint violation
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private Item createItem(Long tmdbId, String title, TmdbType type) {
+        return Item.builder()
+                .tmdbId(tmdbId)
+                .tmdbType(type)
+                .title(title)
+                .overview("Overview for " + title)
+                .releaseDate(LocalDate.now())
+                .popularity(new BigDecimal("100.0000"))
+                .voteAverage(new BigDecimal("7.50"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepositoryTest.java
@@ -209,8 +209,8 @@ class ListFavoriteRepositoryTest {
         ));
 
         // When
-        List<ListFavorite> user1Lists = listFavoriteRepository.findByUser_Id(user1.getId());
-        List<ListFavorite> user2Lists = listFavoriteRepository.findByUser_Id(user2.getId());
+        List<ListFavorite> user1Lists = listFavoriteRepository.findByUserId(user1.getId());
+        List<ListFavorite> user2Lists = listFavoriteRepository.findByUserId(user2.getId());
 
         // Then
         assertThat(user1Lists).hasSize(2);
@@ -225,7 +225,7 @@ class ListFavoriteRepositoryTest {
         userRepository.saveAndFlush(user);
 
         // When
-        List<ListFavorite> lists = listFavoriteRepository.findByUser_Id(user.getId());
+        List<ListFavorite> lists = listFavoriteRepository.findByUserId(user.getId());
 
         // Then
         assertThat(lists).isEmpty();
@@ -238,7 +238,7 @@ class ListFavoriteRepositoryTest {
         UUID nonExistentUserId = UUID.randomUUID();
 
         // When
-        List<ListFavorite> lists = listFavoriteRepository.findByUser_Id(nonExistentUserId);
+        List<ListFavorite> lists = listFavoriteRepository.findByUserId(nonExistentUserId);
 
         // Then
         assertThat(lists).isEmpty();

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/ListFavoriteRepositoryTest.java
@@ -1,0 +1,408 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Item;
+import org.tvl.tvlooker.domain.model.entity.ListFavorite;
+import org.tvl.tvlooker.domain.model.entity.User;
+import org.tvl.tvlooker.domain.model.enums.TmdbType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for ListFavoriteRepository.
+ * Tests cover CRUD operations, custom queries, and relationships.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("ListFavoriteRepository TDD Tests")
+class ListFavoriteRepositoryTest {
+
+    @Autowired
+    private ListFavoriteRepository listFavoriteRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @AfterEach
+    void tearDown() {
+        listFavoriteRepository.deleteAll();
+        itemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new list favorite")
+    void testSaveListFavorite() {
+        // Given - Create user and items WITHOUT saving (ListFavorite has cascade persist)
+        User user = createUser("user1");
+        Item item1 = createItem(1L, "Movie 1");
+        Item item2 = createItem(2L, "Movie 2");
+        Set<Item> items = new HashSet<>();
+        items.add(item1);
+        items.add(item2);
+
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name("My Favorites")
+                .description("My favorite movies")
+                .user(user)
+                .items(items)
+                .build();
+
+        // When - Save list (cascade will persist user and items)
+        ListFavorite savedList = listFavoriteRepository.saveAndFlush(listFavorite);
+
+        // Then
+        assertThat(savedList).isNotNull();
+        assertThat(savedList.getId()).isNotNull();
+        assertThat(savedList.getName()).isEqualTo("My Favorites");
+        assertThat(savedList.getDescription()).isEqualTo("My favorite movies");
+        assertThat(savedList.getUser()).isNotNull();
+        assertThat(savedList.getItems()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Should save list without description")
+    void testSaveListWithoutDescription() {
+        // Given
+        User user = createUser("user1");
+
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name("Favorites List")
+                .description(null)
+                .user(user)
+                .items(new HashSet<>())
+                .build();
+
+        // When
+        ListFavorite savedList = listFavoriteRepository.saveAndFlush(listFavorite);
+
+        // Then
+        assertThat(savedList).isNotNull();
+        assertThat(savedList.getDescription()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should save multiple lists for different users")
+    void testSaveMultipleLists() {
+        // Given
+        User user1 = createUser("user1");
+        User user2 = createUser("user2");
+
+        ListFavorite list1 = ListFavorite.builder()
+                .name("User1 Favorites")
+                .user(user1)
+                .items(new HashSet<>())
+                .build();
+
+        ListFavorite list2 = ListFavorite.builder()
+                .name("User2 Favorites")
+                .user(user2)
+                .items(new HashSet<>())
+                .build();
+
+        // When
+        List<ListFavorite> savedLists = listFavoriteRepository.saveAll(List.of(list1, list2));
+
+        // Then
+        assertThat(savedLists).hasSize(2);
+        assertThat(listFavoriteRepository.count()).isEqualTo(2);
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find list by ID")
+    void testFindById() {
+        // Given
+        User user = createUser("user1");
+        Item item = createItem(1L, "Movie 1");
+        Set<Item> items = new HashSet<>();
+        items.add(item);
+
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name("Findable List")
+                .user(user)
+                .items(items)
+                .build();
+        ListFavorite savedList = listFavoriteRepository.saveAndFlush(listFavorite);
+
+        // When
+        Optional<ListFavorite> foundList = listFavoriteRepository.findById(savedList.getId());
+
+        // Then
+        assertThat(foundList).isPresent();
+        assertThat(foundList.get().getName()).isEqualTo("Findable List");
+    }
+
+    @Test
+    @DisplayName("Should find all lists")
+    void testFindAll() {
+        // Given
+        User user = createUser("user1");
+
+        listFavoriteRepository.saveAll(List.of(
+                ListFavorite.builder().name("List 1").user(user).items(new HashSet<>()).build(),
+                ListFavorite.builder().name("List 2").user(user).items(new HashSet<>()).build()
+        ));
+
+        // When
+        List<ListFavorite> allLists = listFavoriteRepository.findAll();
+
+        // Then
+        assertThat(allLists).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Should count all lists")
+    void testCount() {
+        // Given
+        User user = createUser("user1");
+
+        listFavoriteRepository.saveAll(List.of(
+                ListFavorite.builder().name("List 1").user(user).items(new HashSet<>()).build(),
+                ListFavorite.builder().name("List 2").user(user).items(new HashSet<>()).build()
+        ));
+
+        // When
+        long count = listFavoriteRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== CUSTOM QUERY TESTS ====================
+
+    @Test
+    @DisplayName("Should find lists by user ID")
+    void testFindByUserId() {
+        // Given
+        User user1 = createUser("user1");
+        User user2 = createUser("user2");
+
+        listFavoriteRepository.saveAll(List.of(
+                ListFavorite.builder().name("User1 List 1").user(user1).items(new HashSet<>()).build(),
+                ListFavorite.builder().name("User1 List 2").user(user1).items(new HashSet<>()).build(),
+                ListFavorite.builder().name("User2 List 1").user(user2).items(new HashSet<>()).build()
+        ));
+
+        // When
+        List<ListFavorite> user1Lists = listFavoriteRepository.findByUser_Id(user1.getId());
+        List<ListFavorite> user2Lists = listFavoriteRepository.findByUser_Id(user2.getId());
+
+        // Then
+        assertThat(user1Lists).hasSize(2);
+        assertThat(user2Lists).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Should return empty list when user has no lists")
+    void testFindByUserIdNoLists() {
+        // Given
+        User user = createUser("user1");
+        userRepository.saveAndFlush(user);
+
+        // When
+        List<ListFavorite> lists = listFavoriteRepository.findByUser_Id(user.getId());
+
+        // Then
+        assertThat(lists).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should return empty list for non-existent user ID")
+    void testFindByUserIdNotFound() {
+        // Given
+        UUID nonExistentUserId = UUID.randomUUID();
+
+        // When
+        List<ListFavorite> lists = listFavoriteRepository.findByUser_Id(nonExistentUserId);
+
+        // Then
+        assertThat(lists).isEmpty();
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update list name and description")
+    void testUpdateList() {
+        // Given
+        User user = createUser("user1");
+
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name("Original Name")
+                .description("Original Description")
+                .user(user)
+                .items(new HashSet<>())
+                .build();
+        ListFavorite savedList = listFavoriteRepository.saveAndFlush(listFavorite);
+
+        // When
+        savedList.setName("Updated Name");
+        savedList.setDescription("Updated Description");
+        ListFavorite updatedList = listFavoriteRepository.saveAndFlush(savedList);
+
+        // Then
+        assertThat(updatedList.getId()).isEqualTo(savedList.getId());
+        assertThat(updatedList.getName()).isEqualTo("Updated Name");
+        assertThat(updatedList.getDescription()).isEqualTo("Updated Description");
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete list by ID")
+    void testDeleteById() {
+        // Given
+        User user = createUser("user1");
+
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name("Delete Me")
+                .user(user)
+                .items(new HashSet<>())
+                .build();
+        ListFavorite savedList = listFavoriteRepository.saveAndFlush(listFavorite);
+
+        // When
+        listFavoriteRepository.deleteById(savedList.getId());
+
+        // Then
+        assertThat(listFavoriteRepository.findById(savedList.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all lists")
+    void testDeleteAll() {
+        // Given
+        User user = createUser("user1");
+
+        listFavoriteRepository.saveAll(List.of(
+                ListFavorite.builder().name("List 1").user(user).items(new HashSet<>()).build(),
+                ListFavorite.builder().name("List 2").user(user).items(new HashSet<>()).build()
+        ));
+
+        // When
+        listFavoriteRepository.deleteAll();
+
+        // Then
+        assertThat(listFavoriteRepository.count()).isZero();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should not allow null name")
+    void testNullName() {
+        // Given
+        User user = createUser("user1");
+
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name(null)
+                .user(user)
+                .items(new HashSet<>())
+                .build();
+
+        // When & Then
+        try {
+            listFavoriteRepository.saveAndFlush(listFavorite);
+            fail("Should have thrown exception for null name");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null user")
+    void testNullUser() {
+        // Given
+        ListFavorite listFavorite = ListFavorite.builder()
+                .name("Test List")
+                .user(null)
+                .items(new HashSet<>())
+                .build();
+
+        // When & Then
+        try {
+            listFavoriteRepository.saveAndFlush(listFavorite);
+            fail("Should have thrown exception for null user");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should enforce unique name constraint")
+    void testUniqueName() {
+        // Given
+        User user = createUser("user1");
+
+        ListFavorite list1 = ListFavorite.builder()
+                .name("Unique Name")
+                .user(user)
+                .items(new HashSet<>())
+                .build();
+        listFavoriteRepository.saveAndFlush(list1);
+
+        User user2 = createUser("user2");
+        ListFavorite list2 = ListFavorite.builder()
+                .name("Unique Name")
+                .user(user2)
+                .items(new HashSet<>())
+                .build();
+
+        // When & Then
+        try {
+            listFavoriteRepository.saveAndFlush(list2);
+            fail("Should have thrown exception for duplicate name");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private User createUser(String username) {
+        return User.builder()
+                .username(username)
+                .password("password123")
+                .build();
+    }
+
+    private Item createItem(Long tmdbId, String title) {
+        return Item.builder()
+                .tmdbId(tmdbId)
+                .tmdbType(TmdbType.MOVIE)
+                .title(title)
+                .overview("Overview for " + title)
+                .releaseDate(LocalDate.now())
+                .popularity(new BigDecimal("100.0000"))
+                .voteAverage(new BigDecimal("7.50"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/ReviewRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/ReviewRepositoryTest.java
@@ -204,8 +204,8 @@ class ReviewRepositoryTest {
         reviewRepository.saveAll(List.of(review1, review2, review3));
 
         // When
-        List<Review> user1Reviews = reviewRepository.findByUser_Id(user1.getId());
-        List<Review> user2Reviews = reviewRepository.findByUser_Id(user2.getId());
+        List<Review> user1Reviews = reviewRepository.findByUserId(user1.getId());
+        List<Review> user2Reviews = reviewRepository.findByUserId(user2.getId());
 
         // Then
         assertThat(user1Reviews).hasSize(2);
@@ -224,7 +224,7 @@ class ReviewRepositoryTest {
         userRepository.saveAndFlush(user);
 
         // When
-        List<Review> reviews = reviewRepository.findByUser_Id(user.getId());
+        List<Review> reviews = reviewRepository.findByUserId(user.getId());
 
         // Then
         assertThat(reviews).isEmpty();
@@ -237,7 +237,7 @@ class ReviewRepositoryTest {
         UUID nonExistentUserId = UUID.randomUUID();
 
         // When
-        List<Review> reviews = reviewRepository.findByUser_Id(nonExistentUserId);
+        List<Review> reviews = reviewRepository.findByUserId(nonExistentUserId);
 
         // Then
         assertThat(reviews).isEmpty();

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/ReviewRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/ReviewRepositoryTest.java
@@ -1,0 +1,403 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tvl.tvlooker.domain.model.entity.Item;
+import org.tvl.tvlooker.domain.model.entity.Review;
+import org.tvl.tvlooker.domain.model.entity.User;
+import org.tvl.tvlooker.domain.model.enums.TmdbType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for ReviewRepository.
+ * Tests cover CRUD operations, custom queries, and relationships.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("ReviewRepository TDD Tests")
+class ReviewRepositoryTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @AfterEach
+    void tearDown() {
+        reviewRepository.deleteAll();
+        itemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new review with user and item")
+    void testSaveReview() {
+        // Given - Create objects WITHOUT saving
+        User user = createUser("reviewer1");
+        Item item = createItem(12345L, "The Matrix");
+
+        Review review = Review.builder()
+                .reviewText("Amazing movie!")
+                .score(9)
+                .item(item)
+                .user(user)
+                .build();
+
+        // When - Save review (cascade will persist user and item)
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // Then
+        assertThat(savedReview).isNotNull();
+        assertThat(savedReview.getId()).isNotNull();
+        assertThat(savedReview.getReviewText()).isEqualTo("Amazing movie!");
+        assertThat(savedReview.getScore()).isEqualTo(9);
+        assertThat(savedReview.getUser().getId()).isNotNull();
+        assertThat(savedReview.getItem().getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should save review without text (only score)")
+    void testSaveReviewWithoutText() {
+        // Given
+        User user = createUser("quickrater");
+        Item item = createItem(67890L, "Inception");
+
+        Review review = Review.builder()
+                .reviewText(null)
+                .score(10)
+                .item(item)
+                .user(user)
+                .build();
+
+        // When
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // Then
+        assertThat(savedReview).isNotNull();
+        assertThat(savedReview.getReviewText()).isNull();
+        assertThat(savedReview.getScore()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Should save multiple reviews for different items")
+    void testSaveMultipleReviews() {
+        // Given
+        User user = createUser("critic1");
+        Item item1 = createItem(1L, "Movie 1");
+        Item item2 = createItem(2L, "Movie 2");
+
+        Review review1 = Review.builder().reviewText("Good").score(7).item(item1).user(user).build();
+        Review review2 = Review.builder().reviewText("Great").score(8).item(item2).user(user).build();
+
+        // When
+        List<Review> savedReviews = reviewRepository.saveAll(List.of(review1, review2));
+
+        // Then
+        assertThat(savedReviews).hasSize(2);
+        assertThat(reviewRepository.count()).isEqualTo(2);
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find review by ID")
+    void testFindById() {
+        // Given
+        User user = createUser("finduser");
+        Item item = createItem(100L, "Findable Movie");
+        Review review = Review.builder()
+                .reviewText("Test review")
+                .score(8)
+                .item(item)
+                .user(user)
+                .build();
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // When
+        Optional<Review> foundReview = reviewRepository.findById(savedReview.getId());
+
+        // Then
+        assertThat(foundReview).isPresent();
+        assertThat(foundReview.get().getReviewText()).isEqualTo("Test review");
+        assertThat(foundReview.get().getScore()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("Should find all reviews")
+    void testFindAll() {
+        // Given
+        User user = createUser("user1");
+        Item item1 = createItem(1L, "Item 1");
+        Item item2 = createItem(2L, "Item 2");
+
+        reviewRepository.saveAll(List.of(
+                Review.builder().reviewText("Review 1").score(7).item(item1).user(user).build(),
+                Review.builder().reviewText("Review 2").score(8).item(item2).user(user).build()
+        ));
+
+        // When
+        List<Review> allReviews = reviewRepository.findAll();
+
+        // Then
+        assertThat(allReviews).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Should count all reviews")
+    void testCount() {
+        // Given
+        User user = createUser("counter");
+        Item item1 = createItem(1L, "Item 1");
+        Item item2 = createItem(2L, "Item 2");
+
+        reviewRepository.saveAll(List.of(
+                Review.builder().reviewText("Review 1").score(7).item(item1).user(user).build(),
+                Review.builder().reviewText("Review 2").score(8).item(item2).user(user).build()
+        ));
+
+        // When
+        long count = reviewRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    // ==================== CUSTOM QUERY TESTS ====================
+
+    @Test
+    @DisplayName("Should find reviews by user ID")
+    void testFindByUserId() {
+        // Given
+        User user1 = createUser("user1");
+        User user2 = createUser("user2");
+        Item item1 = createItem(1L, "Item 1");
+        Item item2 = createItem(2L, "Item 2");
+        Item item3 = createItem(3L, "Item 3");
+
+        Review review1 = Review.builder().reviewText("User1 Review 1").score(7).item(item1).user(user1).build();
+        Review review2 = Review.builder().reviewText("User1 Review 2").score(8).item(item2).user(user1).build();
+        Review review3 = Review.builder().reviewText("User2 Review").score(9).item(item3).user(user2).build();
+        
+        reviewRepository.saveAll(List.of(review1, review2, review3));
+
+        // When
+        List<Review> user1Reviews = reviewRepository.findByUser_Id(user1.getId());
+        List<Review> user2Reviews = reviewRepository.findByUser_Id(user2.getId());
+
+        // Then
+        assertThat(user1Reviews).hasSize(2);
+        assertThat(user1Reviews).extracting(Review::getReviewText)
+                .containsExactlyInAnyOrder("User1 Review 1", "User1 Review 2");
+
+        assertThat(user2Reviews).hasSize(1);
+        assertThat(user2Reviews.get(0).getReviewText()).isEqualTo("User2 Review");
+    }
+
+    @Test
+    @DisplayName("Should return empty list when user has no reviews")
+    void testFindByUserIdNoReviews() {
+        // Given
+        User user = createUser("noreviews");
+        userRepository.saveAndFlush(user);
+
+        // When
+        List<Review> reviews = reviewRepository.findByUser_Id(user.getId());
+
+        // Then
+        assertThat(reviews).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should return empty list for non-existent user ID")
+    void testFindByUserIdNotFound() {
+        // Given
+        UUID nonExistentUserId = UUID.randomUUID();
+
+        // When
+        List<Review> reviews = reviewRepository.findByUser_Id(nonExistentUserId);
+
+        // Then
+        assertThat(reviews).isEmpty();
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update review text and score")
+    void testUpdateReview() {
+        // Given
+        User user = createUser("updater");
+        Item item = createItem(300L, "Movie");
+        Review review = Review.builder()
+                .reviewText("Original review")
+                .score(7)
+                .item(item)
+                .user(user)
+                .build();
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // When
+        savedReview.setReviewText("Updated review after second viewing");
+        savedReview.setScore(9);
+        Review updatedReview = reviewRepository.saveAndFlush(savedReview);
+
+        // Then
+        assertThat(updatedReview.getId()).isEqualTo(savedReview.getId());
+        assertThat(updatedReview.getReviewText()).isEqualTo("Updated review after second viewing");
+        assertThat(updatedReview.getScore()).isEqualTo(9);
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete review by ID")
+    void testDeleteById() {
+        // Given
+        User user = createUser("deleter");
+        Item item = createItem(400L, "Movie");
+        Review review = Review.builder()
+                .reviewText("Delete me")
+                .score(5)
+                .item(item)
+                .user(user)
+                .build();
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // When
+        reviewRepository.deleteById(savedReview.getId());
+
+        // Then
+        assertThat(reviewRepository.findById(savedReview.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all reviews")
+    void testDeleteAll() {
+        // Given
+        User user = createUser("user1");
+        Item item1 = createItem(1L, "Item 1");
+        Item item2 = createItem(2L, "Item 2");
+
+        reviewRepository.saveAll(List.of(
+                Review.builder().reviewText("Review 1").score(7).item(item1).user(user).build(),
+                Review.builder().reviewText("Review 2").score(8).item(item2).user(user).build()
+        ));
+
+        // When
+        reviewRepository.deleteAll();
+
+        // Then
+        assertThat(reviewRepository.count()).isZero();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should not allow null item")
+    void testNullItem() {
+        // Given
+        User user = createUser("user");
+        Review review = Review.builder()
+                .reviewText("Test")
+                .score(8)
+                .item(null)
+                .user(user)
+                .build();
+
+        // When & Then
+        try {
+            reviewRepository.saveAndFlush(review);
+            fail("Should have thrown exception for null item");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null user")
+    void testNullUser() {
+        // Given
+        Item item = createItem(500L, "Movie");
+        Review review = Review.builder()
+                .reviewText("Test")
+                .score(8)
+                .item(item)
+                .user(null)
+                .build();
+
+        // When & Then
+        try {
+            reviewRepository.saveAndFlush(review);
+            fail("Should have thrown exception for null user");
+        } catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null score")
+    void testNullScore() {
+        // Given
+        User user = createUser("user");
+        Item item = createItem(600L, "Movie");
+        Review review = Review.builder()
+                .reviewText("Test")
+                .score(0) // Can't set to null due to primitive int
+                .item(item)
+                .user(user)
+                .build();
+
+        // When
+        Review savedReview = reviewRepository.saveAndFlush(review);
+
+        // Then
+        assertThat(savedReview.getScore()).isEqualTo(0);
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private User createUser(String username) {
+        return User.builder()
+                .username(username)
+                .password("password123")
+                .build();
+    }
+
+    private Item createItem(Long tmdbId, String title) {
+        return Item.builder()
+                .tmdbId(tmdbId)
+                .tmdbType(TmdbType.MOVIE)
+                .title(title)
+                .overview("Overview for " + title)
+                .releaseDate(LocalDate.now())
+                .popularity(new BigDecimal("100.0000"))
+                .voteAverage(new BigDecimal("7.50"))
+                .genres(new HashSet<>())
+                .directors(new HashSet<>())
+                .actors(new HashSet<>())
+                .build();
+    }
+}

--- a/src/test/java/org/tvl/tvlooker/persistence/repository/UserRepositoryTest.java
+++ b/src/test/java/org/tvl/tvlooker/persistence/repository/UserRepositoryTest.java
@@ -1,0 +1,386 @@
+package org.tvl.tvlooker.persistence.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.tvl.tvlooker.domain.model.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * TDD Test class for UserRepository.
+ * Tests cover CRUD operations and JpaRepository default methods.
+ *
+ * @author TV Looker Team
+ * @version 1.0
+ * @since 2026-03-11
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("UserRepository TDD Tests")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    // ==================== CREATE/SAVE TESTS ====================
+
+    @Test
+    @DisplayName("Should save a new user and generate UUID")
+    void testSaveUser() {
+        // Given
+        User user = User.builder()
+                .username("testuser")
+                .password("password123")
+                .build();
+
+        // When
+        User savedUser = userRepository.saveAndFlush(user);
+
+        // Then
+        assertThat(savedUser).isNotNull();
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getUsername()).isEqualTo("testuser");
+        assertThat(savedUser.getPassword()).isEqualTo("password123");
+        assertThat(savedUser.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should save multiple users")
+    void testSaveMultipleUsers() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+        User user3 = User.builder().username("user3").password("pass3").build();
+
+        // When
+        List<User> savedUsers = userRepository.saveAll(List.of(user1, user2, user3));
+
+        // Then
+        assertThat(savedUsers).hasSize(3);
+        assertThat(savedUsers).extracting(User::getUsername)
+                .containsExactlyInAnyOrder("user1", "user2", "user3");
+    }
+
+    @Test
+    @DisplayName("Should generate unique UUID for each user")
+    void testUniqueUUIDGeneration() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+
+        // When
+        User savedUser1 = userRepository.save(user1);
+        User savedUser2 = userRepository.save(user2);
+
+        // Then
+        assertThat(savedUser1.getId()).isNotEqualTo(savedUser2.getId());
+    }
+
+    // ==================== READ/FIND TESTS ====================
+
+    @Test
+    @DisplayName("Should find user by ID")
+    void testFindById() {
+        // Given
+        User user = User.builder().username("findme").password("password").build();
+        User savedUser = userRepository.save(user);
+
+        // When
+        Optional<User> foundUser = userRepository.findById(savedUser.getId());
+
+        // Then
+        assertThat(foundUser).isPresent();
+        assertThat(foundUser.get().getUsername()).isEqualTo("findme");
+        assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId());
+    }
+
+    @Test
+    @DisplayName("Should return empty when user ID not found")
+    void testFindByIdNotFound() {
+        // Given
+        UUID nonExistentId = UUID.randomUUID();
+
+        // When
+        Optional<User> foundUser = userRepository.findById(nonExistentId);
+
+        // Then
+        assertThat(foundUser).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should find all users")
+    void testFindAll() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+        User user3 = User.builder().username("user3").password("pass3").build();
+        userRepository.saveAll(List.of(user1, user2, user3));
+
+        // When
+        List<User> allUsers = userRepository.findAll();
+
+        // Then
+        assertThat(allUsers).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should check if user exists by ID")
+    void testExistsById() {
+        // Given
+        User user = User.builder().username("exists").password("password").build();
+        User savedUser = userRepository.save(user);
+
+        // When
+        boolean exists = userRepository.existsById(savedUser.getId());
+        boolean notExists = userRepository.existsById(UUID.randomUUID());
+
+        // Then
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should count all users")
+    void testCount() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+        userRepository.saveAll(List.of(user1, user2));
+
+        // When
+        long count = userRepository.count();
+
+        // Then
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Should find all users by IDs")
+    void testFindAllById() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+        User user3 = User.builder().username("user3").password("pass3").build();
+        User savedUser1 = userRepository.save(user1);
+        User savedUser2 = userRepository.save(user2);
+        userRepository.save(user3);
+
+        // When
+        List<User> users = userRepository.findAllById(List.of(savedUser1.getId(), savedUser2.getId()));
+
+        // Then
+        assertThat(users).hasSize(2);
+        assertThat(users).extracting(User::getUsername)
+                .containsExactlyInAnyOrder("user1", "user2");
+    }
+
+    // ==================== UPDATE TESTS ====================
+
+    @Test
+    @DisplayName("Should update existing user")
+    void testUpdateUser() {
+        // Given
+        User user = User.builder().username("oldname").password("oldpass").build();
+        User savedUser = userRepository.save(user);
+
+        // When
+        savedUser.setUsername("newname");
+        savedUser.setPassword("newpass");
+        User updatedUser = userRepository.save(savedUser);
+
+        // Then
+        assertThat(updatedUser.getId()).isEqualTo(savedUser.getId());
+        assertThat(updatedUser.getUsername()).isEqualTo("newname");
+        assertThat(updatedUser.getPassword()).isEqualTo("newpass");
+    }
+
+    @Test
+    @DisplayName("Should update user and persist changes")
+    void testUpdateUserPersisted() {
+        // Given
+        User user = User.builder().username("original").password("password").build();
+        User savedUser = userRepository.save(user);
+        UUID userId = savedUser.getId();
+
+        // When
+        savedUser.setUsername("updated");
+        userRepository.save(savedUser);
+        userRepository.flush();
+
+        // Then
+        Optional<User> reloadedUser = userRepository.findById(userId);
+        assertThat(reloadedUser).isPresent();
+        assertThat(reloadedUser.get().getUsername()).isEqualTo("updated");
+    }
+
+    // ==================== DELETE TESTS ====================
+
+    @Test
+    @DisplayName("Should delete user by ID")
+    void testDeleteById() {
+        // Given
+        User user = User.builder().username("deleteme").password("password").build();
+        User savedUser = userRepository.save(user);
+
+        // When
+        userRepository.deleteById(savedUser.getId());
+
+        // Then
+        Optional<User> deletedUser = userRepository.findById(savedUser.getId());
+        assertThat(deletedUser).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete user entity")
+    void testDelete() {
+        // Given
+        User user = User.builder().username("deleteme").password("password").build();
+        User savedUser = userRepository.save(user);
+
+        // When
+        userRepository.delete(savedUser);
+
+        // Then
+        Optional<User> deletedUser = userRepository.findById(savedUser.getId());
+        assertThat(deletedUser).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should delete all users")
+    void testDeleteAll() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+        userRepository.saveAll(List.of(user1, user2));
+
+        // When
+        userRepository.deleteAll();
+
+        // Then
+        assertThat(userRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("Should delete all users by IDs")
+    void testDeleteAllById() {
+        // Given
+        User user1 = User.builder().username("user1").password("pass1").build();
+        User user2 = User.builder().username("user2").password("pass2").build();
+        User user3 = User.builder().username("user3").password("pass3").build();
+        User savedUser1 = userRepository.save(user1);
+        User savedUser2 = userRepository.save(user2);
+        User savedUser3 = userRepository.save(user3);
+
+        // When
+        userRepository.deleteAllById(List.of(savedUser1.getId(), savedUser2.getId()));
+
+        // Then
+        assertThat(userRepository.count()).isEqualTo(1);
+        Optional<User> remainingUser = userRepository.findById(savedUser3.getId());
+        assertThat(remainingUser).isPresent();
+    }
+
+    // ==================== CONSTRAINT TESTS ====================
+
+    @Test
+    @DisplayName("Should enforce username uniqueness constraint")
+    void testUsernameUniqueConstraint() {
+        // Given
+        User user1 = User.builder().username("duplicate").password("pass1").build();
+        userRepository.save(user1);
+        userRepository.flush();
+
+        User user2 = User.builder().username("duplicate").password("pass2").build();
+
+        // When & Then
+        try {
+            userRepository.save(user2);
+            userRepository.flush();
+            fail("Should have thrown exception for duplicate username");
+        } catch (Exception e) {
+            // Expected exception due to unique constraint violation
+            assertThat(e.getMessage()).containsAnyOf("unique", "constraint", "duplicate", "Unique");
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null username")
+    void testNullUsername() {
+        // Given
+        User user = User.builder().username(null).password("password").build();
+
+        // When & Then
+        try {
+            userRepository.save(user);
+            userRepository.flush();
+            fail("Should have thrown exception for null username");
+        } catch (Exception e) {
+            // Expected exception due to null constraint violation
+            assertThat(e).isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not allow null password")
+    void testNullPassword() {
+        // Given
+        User user = User.builder().username("validuser").password(null).build();
+
+        // When & Then
+        try {
+            userRepository.save(user);
+            userRepository.flush();
+            fail("Should have thrown exception for null password");
+        } catch (Exception e) {
+            // Expected exception due to null constraint violation
+            assertThat(e).isNotNull();
+        }
+    }
+
+    // ==================== TIMESTAMP TESTS ====================
+
+    @Test
+    @DisplayName("Should automatically set createdAt timestamp on save")
+    void testCreatedAtTimestamp() {
+        // Given
+        User user = User.builder().username("timestamptest").password("password").build();
+
+        // When
+        User savedUser = userRepository.saveAndFlush(user);
+
+        // Then
+        assertThat(savedUser.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should not modify createdAt on update")
+    void testCreatedAtImmutable() {
+        // Given
+        User user = User.builder().username("immutable").password("password").build();
+        User savedUser = userRepository.save(user);
+        userRepository.flush();
+
+        // When
+        savedUser.setPassword("newpassword");
+        User updatedUser = userRepository.save(savedUser);
+        userRepository.flush();
+
+        // Then
+        assertThat(updatedUser.getCreatedAt()).isEqualTo(savedUser.getCreatedAt());
+    }
+}


### PR DESCRIPTION
## 📌 Descripción
Implementado los repositorios JPA para cada entidad, algunos con operaciones de consulta personalizadas. Se crearon 115 pruebas que cubren operaciones CRUD, métodos de consulta personalizados, relaciones entre entidades, comportamiento en cascada y validaciones de restricciones.

## 🧪 Tipo de cambio
- [x] Tests
- [x] Nueva funcionalidad

## ✅ Checklist
- [x] El código compila
- [x] Los tests pasan (115 tests)
- [x] Se ejecutó `mvn clean verify`
- [x] Cumple Checkstyle y PMD

## 🔗 Issue relacionado
- #43 

## Tests Creados
- UserRepositoryTest (20 tests)
- ItemRepositoryTest (19 tests)
- ReviewRepositoryTest (15 tests)
- InteractionRepositoryTest (15 tests)
- ListFavoriteRepositoryTest (15 tests)
- GenreRepositoryTest (9 tests)
- DirectorRepositoryTest (11 tests)
- ActorRepositoryTest (11 tests)