### PR TITLE
refactor: Implementar paginación en endpoints de gran volumen (getAll)

### DIFF
--- a/docs/plans/2026-04-17-pagination-design.md
+++ b/docs/plans/2026-04-17-pagination-design.md
@@ -1,0 +1,43 @@
+# Pagination Strategy Design for `getAllItems`
+
+## 1. Overview
+The `getAllItems` API endpoint currently causes frontend applications to crash when it attempts to load and render thousands of records simultaneously (>10,000 items). To alleviate these memory and performance issues, we are transitioning to an **Offset-based Pagination** strategy via Spring Data JPA's native capabilities.
+
+## 2. Core Strategy & API Definition
+- **Pagination Strategy**: Offset-based, `Page<T>` implementation.
+- **Default Page Size**: `50` items per page.
+  - *Justification*: 50 items is a "sweet spot" size that allows seamless rendering on standard UIs without DOM freezing or frontend memory exhaustion, while maintaining a very fast backend response time.
+- **Max Page Size Constraint**: We will cap requests at `1000` items maximum per request to prevent intentional or accidental massive queries.
+- **API Example**: 
+  `GET /api/items?page=0&size=50&sort=id,desc`
+
+## 3. Backend Technical Approach
+- **Framework integration**: We will utilize Spring Data JPA's `Pageable` and `Page<T>` interface.
+- **Controller Layer**: Inject `Pageable` directly into the mapped Controller endpoint method, annotated with `@PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC)`.
+- **Repository/Service Layer**: Convert `List<Item> findAll()` methods to `Page<Item> findAll(Pageable pageable)`.
+- **Response Shape**: The API payload will switch from a raw array to a metadata-rich JSON envelope:
+  ```json
+  {
+    "content": [{ "id": 1, "name": "Item Name" }],
+    "pageable": { "sort": { ... }, "pageNumber": 0, "pageSize": 50 },
+    "totalPages": 200,
+    "totalElements": 10000,
+    "last": false,
+    "size": 50,
+    "number": 0
+  }
+  ```
+
+## 4. Frontend Impact
+- **Resolution**: Fetching fixed sizes of 50 items natively stops the memory overload problem crashing the client.
+- **Integration**: The frontend UI requires updating to read `content` inside the envelope, and render table-style Pagination Controls based on `totalPages` and the current `number`.
+- **Loading states**: The frontend needs intermediate loading states when requesting the next page of `50`.
+
+## 5. Error Handling
+- **Constraint Handling**: Enforce a global configuration `spring.data.web.pageable.max-page-size=1000`.
+- **Invalid parameters**: Any malformed or negative page requests will be caught by Spring's `MethodArgumentNotValidException`, returning a standard 400 Bad Request.
+- **Out of bounds paging**: Requesting page `9999` when only 200 exist returns an empty `"content": []` array instead of throwing an unhandled exception, providing standard API robustness.
+
+## 6. Future Scalability & Recommendation Integration
+- **Per-Pagination Recommendations**: When building per-page contextual recommendations in the future, the backend will compute these strictly against the `O(N)` bounds of the current page size (`N=50`), ensuring the recommendations API remains extremely fast. This could optionally be triggered by an `includeRecommendations=true` query parameter, injected directly into the response envelope.
+- **Aggregated Best Recommendations**: Instead of scanning millions of records on the fly, a background worker or materialized view will aggregate and compute top recommendations asynchronously. A secondary endpoint (`GET /api/recommendations/top`) will serve these paginated, pre-computed recommendations globally, preventing any single endpoint from being a scalability bottleneck.

--- a/docs/plans/2026-04-17-pagination-implementation.md
+++ b/docs/plans/2026-04-17-pagination-implementation.md
@@ -1,0 +1,252 @@
+# Pagination Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement offset-based pagination on the `getAllItems` API endpoint to handle large data volumes and prevent frontend memory overload.
+
+**Architecture:** We use Spring Data JPA's native `Pageable` and `Page<T>` types. The `ItemRepository` already supports `findAll(Pageable)` natively by extending `JpaRepository`. We will expose a new `getAll(Pageable)` method in the `ItemService` (leaving the no-arg `getAll()` intact for internal usages) and adapt `ItemController` to consume the page parameters and return a structured `Page<ItemResponse>`.
+
+**Tech Stack:** Java, Spring Boot, Spring Data JPA, MockMvc
+
+---
+
+### Task 1: Application Configuration
+
+**Files:**
+- Modify: `src/main/resources/application.properties`
+
+- [ ] **Step 1: Set max page size limit**
+
+Append the following configuration to `src/main/resources/application.properties` at the bottom of the "Application Configuration" block (around line 25):
+
+```properties
+# Pagination Configuration
+spring.data.web.pageable.max-page-size=1000
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/main/resources/application.properties
+git commit -m "chore: configure max page size for pagination"
+```
+
+---
+
+### Task 2: Service Layer Implementation
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/ItemService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/ItemServiceTest.java`
+
+- [ ] **Step 1: Write failing test in `ItemServiceTest.java`**
+
+First, add necessary imports at the top of `src/test/java/org/tvl/tvlooker/service/ItemServiceTest.java`:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+```
+
+Then add this new test method inside the class:
+
+```java
+    @Test
+    void givenPageable_whenGetAll_thenReturnsPageOfItems() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        List<ItemEntity> entities = List.of(itemEntity, createItemEntityWithId(2L));
+        Page<ItemEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+        
+        when(itemRepository.findAll(pageable)).thenReturn(entityPage);
+
+        // Act
+        Page<Item> result = itemService.getAll(pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals(2, result.getContent().size());
+        assertEquals("Test Title", result.getContent().get(0).getTitle());
+        verify(itemRepository, times(1)).findAll(pageable);
+    }
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `mvnw test -Dtest=ItemServiceTest#givenPageable_whenGetAll_thenReturnsPageOfItems`
+Expected: Compilation failure because `itemService.getAll(Pageable)` doesn't exist.
+
+- [ ] **Step 3: Implement `getAll(Pageable)` in `ItemService.java`**
+
+Add imports to `src/main/java/org/tvl/tvlooker/service/ItemService.java`:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+```
+
+Add the method logic below the existing `getAll()`:
+
+```java
+    /**
+     * Get all items with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of items
+     */
+    public Page<Item> getAll(Pageable pageable) {
+        return itemRepository.findAll(pageable)
+                .map(ItemEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvnw test -Dtest=ItemServiceTest#givenPageable_whenGetAll_thenReturnsPageOfItems`
+Expected: Passes successfully.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/org/tvl/tvlooker/service/ItemService.java src/test/java/org/tvl/tvlooker/service/ItemServiceTest.java
+git commit -m "feat: add paginated getAll method to ItemService"
+```
+
+---
+
+### Task 3: Controller Layer Implementation
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/ItemController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/ItemControllerTest.java`
+
+- [ ] **Step 1: Update MockMvc configuration and write failing tests**
+
+In `src/test/java/org/tvl/tvlooker/api/controller/ItemControllerTest.java`, add the imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+```
+
+Update `setUp()` to support Pageable:
+```java
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(itemController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+        // ... (keep the rest of setUp)
+```
+
+Replace the ENTIRE `GetAllItems` nested class with the new tests reflecting pagination structure:
+
+```java
+    @Nested
+    class GetAllItems {
+
+        @Test
+        void givenItemsExist_whenGetAllItems_thenReturnsPaginatedList() throws Exception {
+            Item secondItem = Item.builder()
+                    .id(2L)
+                    .title("Test TV Show")
+                    .overview("This is a test TV show overview")
+                    .releaseDate(LocalDate.of(2024, 2, 20))
+                    .popularity(new BigDecimal("8.0"))
+                    .voteAverage(new BigDecimal("8.5"))
+                    .tmdbType(TmdbType.TV)
+                    .tmdbId(67890L)
+                    .genres(new HashSet<>())
+                    .directors(new HashSet<>())
+                    .actorsInItem(new HashSet<>())
+                    .build();
+            List<Item> items = Arrays.asList(testItem, secondItem);
+            Page<Item> itemPage = new PageImpl<>(items, PageRequest.of(0, 50), items.size());
+
+            when(itemService.getAll(any(Pageable.class))).thenReturn(itemPage);
+
+            mockMvc.perform(get("/api/v1/items")
+                            .param("page", "0")
+                            .param("size", "50"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.content[0].title", is("Test Movie")))
+                    .andExpect(jsonPath("$.content[1].title", is("Test TV Show")))
+                    .andExpect(jsonPath("$.totalElements", is(2)))
+                    .andExpect(jsonPath("$.totalPages", is(1)))
+                    .andExpect(jsonPath("$.size", is(50)))
+                    .andExpect(jsonPath("$.number", is(0)));
+
+            verify(itemService, times(1)).getAll(any(Pageable.class));
+        }
+
+        @Test
+        void givenNoItems_whenGetAllItems_thenReturnsEmptyPage() throws Exception {
+            Page<Item> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(itemService.getAll(any(Pageable.class))).thenReturn(emptyPage);
+
+            mockMvc.perform(get("/api/v1/items"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalElements", is(0)));
+
+            verify(itemService, times(1)).getAll(any(Pageable.class));
+        }
+    }
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `mvnw test -Dtest=ItemControllerTest`
+Expected: Compilation or runtime failure because `itemController.getAllItems` returns a List, or `itemService.getAll(Pageable)` isn't mocked properly against the controller yet.
+
+- [ ] **Step 3: Implement pagination in `ItemController.java`**
+
+Add imports to `src/main/java/org/tvl/tvlooker/api/controller/ItemController.java`:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+```
+
+Update `getAllItems` method in `ItemController.java` to:
+
+```java
+    /**
+     * Retrieves all items with pagination.
+     * @param pageable Pagination configuration.
+     * @return A paginated list of item responses.
+     */
+    @GetMapping
+    public ResponseEntity<Page<ItemResponse>> getAllItems(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Item> itemsPage = ITEM_SERVICE.getAll(pageable);
+        Page<ItemResponse> response = itemsPage.map(ItemMapper::toResponse);
+        return ResponseEntity.ok(response);
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvnw test -Dtest=ItemControllerTest`
+Expected: All tests pass successfully.
+
+- [ ] **Step 5: Run full test suite for regression check**
+
+Run: `mvnw test`
+Expected: All tests in the project should pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/org/tvl/tvlooker/api/controller/ItemController.java src/test/java/org/tvl/tvlooker/api/controller/ItemControllerTest.java
+git commit -m "feat: implement offset-based pagination in ItemController getAllItems"
+```

--- a/docs/plans/2026-04-18-pagination-all-controllers-design.md
+++ b/docs/plans/2026-04-18-pagination-all-controllers-design.md
@@ -1,0 +1,65 @@
+# Pagination Strategy for All GetAll Endpoints
+
+## 1. Overview & Scope
+
+- **Goal**: Apply the same offset-based pagination pattern to 6 controllers to prevent frontend memory overload when sending large datasets.
+- **Controllers to update**: Actor, Director, Interaction, ListFavorite, Review, User (excluding Genre per user request)
+- **Pattern**: Same as ItemController — `@PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC)` returning `PageResponse<TResponse>`
+- **Max Page Size**: Enforced globally via `spring.data.web.pageable.max-page-size=1000` (already configured)
+
+## 2. Technical Approach
+
+- **Reusable Generic `PageResponse<T>`**: Already exists in `api/dto/response/PageResponse.java`
+  ```java
+  public record PageResponse<T>(
+      List<T> content,
+      long totalItems,
+      int actualPage,
+      int totalPages,
+      boolean isLast
+  ){}
+  ```
+
+- **Controller Pattern** (same for all 6):
+  - Accept `Pageable pageable` with `@PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC)`
+  - Return `ResponseEntity<PageResponse<TResponse>>` 
+  - Service transformation: `Page<Entity> → Page<DTO>`, then wrap in `PageResponse<TResponse>`
+  - Use existing mappers to convert entity → DTO (not the repository `Page` directly)
+
+- **Testing**: Each controller gets pagination tests similar to ItemControllerTest
+
+## 3. Implementation Order
+
+Following the subagent-driven-development pattern with TDD:
+
+1. **Actor** - Service + Controller + Tests
+2. **Director** - Service + Controller + Tests
+3. **Interaction** - Service + Controller + Tests
+4. **ListFavorite** - Service + Controller + Tests
+5. **Review** - Service + Controller + Tests
+6. **User** - Service + Controller + Tests
+
+## 4. API Usage
+
+All endpoints will accept:
+```
+GET /api/v1/{entity}?page=0&size=50&sort=id,desc
+```
+
+And return the paginated `PageResponse<T>` structure:
+```json
+{
+  "content": [...],
+  "totalItems": 10000,
+  "actualPage": 0,
+  "totalPages": 200,
+  "isLast": false
+}
+```
+
+## 5. Error Handling
+
+Same as ItemController:
+- Invalid parameters → 400 Bad Request (handled by Spring)
+- Out of bounds page → Empty `content: []` array
+- Max page size enforced to 1000

--- a/docs/plans/2026-04-18-pagination-all-controllers-implementation.md
+++ b/docs/plans/2026-04-18-pagination-all-controllers-implementation.md
@@ -1,0 +1,480 @@
+# Pagination Implementation for All GetAll Endpoints
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement offset-based pagination on 6 controllers (Actor, Director, Interaction, ListFavorite, Review, User) using the generic PageResponse<T> DTO.
+
+**Architecture:** Same pattern as ItemController - add `getAll(Pageable)` to each service, update controller to accept `Pageable` and return `PageResponse<TResponse>`. Use existing mappers to convert entity → DTO.
+
+**Tech Stack:** Java, Spring Boot, Spring Data JPA, MockMvc
+
+**Note:** `PageResponse<T>` DTO already exists at `src/main/java/org/tvl/tvlooker/api/dto/response/PageResponse.java`
+
+---
+
+## Task 1: ActorController Pagination
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/ActorService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/ActorServiceTest.java`
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/ActorController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/ActorControllerTest.java`
+
+- [ ] **Step 1: Add getAll(Pageable) to ActorService**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+```
+
+Add method:
+```java
+    /**
+     * Get all actors with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of actors
+     */
+    public Page<Actor> getAll(Pageable pageable) {
+        return actorRepository.findAll(pageable)
+                .map(ActorEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 2: Add test for getAll(Pageable) in ActorServiceTest**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+```
+
+Add test:
+```java
+    @Test
+    void givenPageable_whenGetAll_thenReturnsPageOfActors() {
+        Pageable pageable = PageRequest.of(0, 10);
+        List<ActorEntity> entities = List.of(actorEntity, createActorEntityWithId(2L));
+        Page<ActorEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+        
+        when(actorRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Actor> result = actorService.getAll(pageable);
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        verify(actorRepository, times(1)).findAll(pageable);
+    }
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `mvnw test -Dtest=ActorServiceTest#givenPageable_whenGetAll_thenReturnsPageOfActors`
+Expected: Pass
+
+- [ ] **Step 4: Update ActorController for pagination**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
+```
+
+Update getAllActors method:
+```java
+    @GetMapping
+    public ResponseEntity<PageResponse<ActorResponse>> getAllActors(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Actor> actorsPage = actorService.getAll(pageable);
+        
+        List<ActorResponse> content = actorsPage.getContent().stream()
+                .map(actor -> ActorResponse.builder()
+                        .id(actor.getId())
+                        .name(actor.getName())
+                        .tmdbId(actor.getTmdbId())
+                        .build())
+                .toList();
+        
+        PageResponse<ActorResponse> response = new PageResponse<>(
+                content,
+                actorsPage.getTotalElements(),
+                actorsPage.getNumber(),
+                actorsPage.getTotalPages(),
+                actorsPage.isLast()
+        );
+        return ResponseEntity.ok(response);
+    }
+```
+
+- [ ] **Step 5: Update ActorControllerTest**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+```
+
+Update setUp() to support Pageable:
+```java
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(actorController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+```
+
+Replace GetAllActors tests with pagination tests:
+```java
+    @Nested
+    class GetAllActors {
+
+        @Test
+        void givenActorsExist_whenGetAllActors_thenReturnsPaginatedList() throws Exception {
+            Actor secondActor = Actor.builder()
+                    .id(2L)
+                    .name("Actor Two")
+                    .tmdbId(22222L)
+                    .build();
+            List<Actor> actors = Arrays.asList(testActor, secondActor);
+            Page<Actor> actorPage = new PageImpl<>(actors, PageRequest.of(0, 50), actors.size());
+
+            when(actorService.getAll(any(Pageable.class))).thenReturn(actorPage);
+
+            mockMvc.perform(get("/api/v1/actors")
+                            .param("page", "0")
+                            .param("size", "50"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
+
+            verify(actorService, times(1)).getAll(any(Pageable.class));
+        }
+
+        @Test
+        void givenNoActors_whenGetAllActors_thenReturnsEmptyPage() throws Exception {
+            Page<Actor> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(actorService.getAll(any(Pageable.class))).thenReturn(emptyPage);
+
+            mockMvc.perform(get("/api/v1/actors"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
+
+            verify(actorService, times(1)).getAll(any(Pageable.class));
+        }
+    }
+```
+
+- [ ] **Step 6: Run tests to verify**
+
+Run: `mvnw test -Dtest=ActorControllerTest`
+Expected: Pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/java/org/tvl/tvlooker/service/ActorService.java src/test/java/org/tvl/tvlooker/service/ActorServiceTest.java src/main/java/org/tvl/tvlooker/api/controller/ActorController.java src/test/java/org/tvl/tvlooker/api/controller/ActorControllerTest.java
+git commit -m "feat: add pagination to ActorController getAllActors"
+```
+
+---
+
+## Task 2: DirectorController Pagination
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/DirectorService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/DirectorServiceTest.java`
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/DirectorController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/DirectorControllerTest.java`
+
+- [ ] **Step 1: Add getAll(Pageable) to DirectorService**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+```
+
+Add method:
+```java
+    /**
+     * Get all directors with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of directors
+     */
+    public Page<Director> getAll(Pageable pageable) {
+        return directorRepository.findAll(pageable)
+                .map(DirectorEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 2: Add test for getAll(Pageable) in DirectorServiceTest**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+```
+
+Add test:
+```java
+    @Test
+    void givenPageable_whenGetAll_thenReturnsPageOfDirectors() {
+        Pageable pageable = PageRequest.of(0, 10);
+        List<DirectorEntity> entities = List.of(directorEntity, createDirectorEntityWithId(2L));
+        Page<DirectorEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+        
+        when(directorRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Director> result = directorService.getAll(pageable);
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        verify(directorRepository, times(1)).findAll(pageable);
+    }
+```
+
+- [ ] **Step 3: Run test to verify**
+
+Run: `mvnw test -Dtest=DirectorServiceTest#givenPageable_whenGetAll_thenReturnsPageOfDirectors`
+Expected: Pass
+
+- [ ] **Step 4: Update DirectorController for pagination**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
+```
+
+Update getAllDirectors method:
+```java
+    @GetMapping
+    public ResponseEntity<PageResponse<DirectorResponse>> getAllDirectors(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Director> directorsPage = directorService.getAll(pageable);
+        
+        List<DirectorResponse> content = directorsPage.getContent().stream()
+                .map(DirectorMapper::toResponse)
+                .toList();
+        
+        PageResponse<DirectorResponse> response = new PageResponse<>(
+                content,
+                directorsPage.getTotalElements(),
+                directorsPage.getNumber(),
+                directorsPage.getTotalPages(),
+                directorsPage.isLast()
+        );
+        return ResponseEntity.ok(response);
+    }
+```
+
+- [ ] **Step 5: Update DirectorControllerTest**
+
+Add imports:
+```java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+```
+
+Update setUp():
+```java
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(directorController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+```
+
+Replace GetAllDirectors tests with pagination tests (same pattern as ActorControllerTest, but for /api/v1/directors endpoint):
+
+- [ ] **Step 6: Run tests**
+
+Run: `mvnw test -Dtest=DirectorControllerTest`
+Expected: Pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/java/org/tvl/tvlooker/service/DirectorService.java src/test/java/org/tvl/tvlooker/service/DirectorServiceTest.java src/main/java/org/tvl/tvlooker/api/controller/DirectorController.java src/test/java/org/tvl/tvlooker/api/controller/DirectorControllerTest.java
+git commit -m "feat: add pagination to DirectorController getAllDirectors"
+```
+
+---
+
+## Task 3: InteractionController Pagination
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/InteractionService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/InteractionServiceTest.java`
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/InteractionController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/InteractionControllerTest.java`
+
+- [ ] **Step 1: Add getAll(Pageable) to InteractionService**
+
+```java
+    /**
+     * Get all interactions with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of interactions
+     */
+    public Page<Interaction> getAll(Pageable pageable) {
+        return interactionRepository.findAll(pageable)
+                .map(InteractionEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 2: Add test for getAll(Pageable)**
+
+Add test similar to previous services.
+
+- [ ] **Step 3: Update InteractionController**
+
+Update getAllInteractions method to use Pageable and return PageResponse:
+
+```java
+    @GetMapping
+    public ResponseEntity<PageResponse<InteractionResponse>> getAllInteractions(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Interaction> interactionsPage = interactionService.getAll(pageable);
+        
+        List<InteractionResponse> content = interactionsPage.getContent().stream()
+                .map(InteractionMapper::toResponse)
+                .toList();
+        
+        PageResponse<InteractionResponse> response = new PageResponse<>(
+                content,
+                interactionsPage.getTotalElements(),
+                interactionsPage.getNumber(),
+                interactionsPage.getTotalPages(),
+                interactionsPage.isLast()
+        );
+        return ResponseEntity.ok(response);
+    }
+```
+
+- [ ] **Step 4: Update InteractionControllerTest**
+
+Add Pageable support and pagination tests.
+
+- [ ] **Step 5: Run tests and commit**
+
+Run: `mvnw test -Dtest=InteractionControllerTest`
+Commit with appropriate message.
+
+---
+
+## Task 4: ListFavoriteController Pagination
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/ListFavoriteService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/ListFavoriteServiceTest.java`
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/ListFavoriteController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/ListFavoriteControllerTest.java`
+
+- [ ] **Step 1: Add getAll(Pageable) to ListFavoriteService**
+
+```java
+    public Page<ListFavorite> getAll(Pageable pageable) {
+        return listFavoriteRepository.findAll(pageable)
+                .map(ListFavoriteEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 2: Add test and implement**
+
+- [ ] **Step 3: Update ListFavoriteController**
+
+Method `listFavorites()` becomes paginated.
+
+- [ ] **Step 4: Update tests and commit**
+
+---
+
+## Task 5: ReviewController Pagination
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/ReviewService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/ReviewServiceTest.java`
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/ReviewController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/ReviewControllerTest.java`
+
+- [ ] **Step 1: Add getAll(Pageable) to ReviewService**
+
+```java
+    public Page<Review> getAll(Pageable pageable) {
+        return reviewRepository.findAll(pageable)
+                .map(ReviewEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 2: Add test and implement**
+
+- [ ] **Step 3: Update ReviewController**
+
+Method `getAllReviews()` becomes paginated.
+
+- [ ] **Step 4: Update tests and commit**
+
+---
+
+## Task 6: UserController Pagination
+
+**Files:**
+- Modify: `src/main/java/org/tvl/tvlooker/service/UserService.java`
+- Modify: `src/test/java/org/tvl/tvlooker/service/UserServiceTest.java`
+- Modify: `src/main/java/org/tvl/tvlooker/api/controller/UserController.java`
+- Modify: `src/test/java/org/tvl/tvlooker/api/controller/UserControllerTest.java`
+
+- [ ] **Step 1: Add getAll(Pageable) to UserService**
+
+```java
+    public Page<User> getAll(Pageable pageable) {
+        return userRepository.findAll(pageable)
+                .map(UserEntityMapper::toDomain);
+    }
+```
+
+- [ ] **Step 2: Add test and implement**
+
+- [ ] **Step 3: Update UserController**
+
+Method `getAllUsers()` becomes paginated.
+
+- [ ] **Step 4: Update tests and commit**
+
+---
+
+## Final: Run Full Test Suite
+
+After all tasks are complete, run the full test suite to ensure no regressions:
+
+```bash
+mvnw test
+```
+
+Expected: All tests pass.

--- a/src/main/java/org/tvl/tvlooker/api/controller/ActorController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/ActorController.java
@@ -1,12 +1,17 @@
 package org.tvl.tvlooker.api.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.tvl.tvlooker.api.dto.response.ActorResponse;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
 import org.tvl.tvlooker.domain.model.dto.Actor;
 import org.tvl.tvlooker.service.ActorService;
 
@@ -23,18 +28,30 @@ public class ActorController {
 
     /**
      * Retrieves all actors.
-     * @return a list of actor responses
+     * @param pageable pagination information
+     * @return a page of actor responses
      */
     @GetMapping
-    public ResponseEntity<List<ActorResponse>> getAllActors() {
-        List<ActorResponse> actors = actorService.getAll().stream()
+    public ResponseEntity<PageResponse<ActorResponse>> getAllActors(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Actor> actorsPage = actorService.getAll(pageable);
+        
+        List<ActorResponse> content = actorsPage.getContent().stream()
                 .map(actor -> ActorResponse.builder()
                         .id(actor.getId())
                         .name(actor.getName())
                         .tmdbId(actor.getTmdbId())
                         .build())
                 .toList();
-        return ResponseEntity.ok(actors);
+        
+        PageResponse<ActorResponse> response = new PageResponse<>(
+                content,
+                actorsPage.getTotalElements(),
+                actorsPage.getNumber(),
+                actorsPage.getTotalPages(),
+                actorsPage.isLast()
+        );
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/api/controller/DirectorController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/DirectorController.java
@@ -1,17 +1,21 @@
 package org.tvl.tvlooker.api.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.tvl.tvlooker.api.dto.mapper.DirectorMapper;
+import org.tvl.tvlooker.api.dto.mapper.PageMapper;
 import org.tvl.tvlooker.api.dto.response.DirectorResponse;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
 import org.tvl.tvlooker.domain.model.dto.Director;
 import org.tvl.tvlooker.service.DirectorService;
-
-import java.util.List;
 
 /**
  * REST controller for managing directors.
@@ -23,16 +27,16 @@ public class DirectorController {
     private final DirectorService directorService;
 
     /**
-     * Retrieves all directors.
-     * @return a list of director responses
+     * Retrieves all directors with pagination.
+     * @param pageable Pagination configuration.
+     * @return a paginated list of director responses
      */
     @GetMapping
-    public ResponseEntity<List<DirectorResponse>> getAllDirectors() {
-        List<Director> directors = directorService.getAll();
-        return ResponseEntity.ok(directors.stream()
-                .map(DirectorMapper::toResponse)
-                .toList()
-        );
+    public ResponseEntity<PageResponse<DirectorResponse>> getAllDirectors(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Director> directorsPage = directorService.getAll(pageable);
+        PageResponse<DirectorResponse> response = PageMapper.toResponse(directorsPage.map(DirectorMapper::toResponse));
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/api/controller/InteractionController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/InteractionController.java
@@ -1,6 +1,10 @@
 package org.tvl.tvlooker.api.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +19,7 @@ import org.tvl.tvlooker.api.dto.mapper.InteractionMapper;
 import org.tvl.tvlooker.api.dto.request.CreateInteractionRequest;
 import org.tvl.tvlooker.api.dto.request.UpdateInteractionRequest;
 import org.tvl.tvlooker.api.dto.response.InteractionResponse;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
 import org.tvl.tvlooker.domain.model.dto.Interaction;
 import org.tvl.tvlooker.service.InteractionService;
 
@@ -35,11 +40,21 @@ public class InteractionController {
      * @return list of interaction responses
      */
     @GetMapping
-    public ResponseEntity<List<InteractionResponse>> getAllInteractions(){
-        List<Interaction> interactions = interactionService.getAll();;
-        List<InteractionResponse> response = interactions.stream()
+    public ResponseEntity<PageResponse<InteractionResponse>> getAllInteractions(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Interaction> interactionsPage = interactionService.getAll(pageable);
+
+        List<InteractionResponse> content = interactionsPage.getContent().stream()
                 .map(InteractionMapper::toResponse)
                 .toList();
+
+        PageResponse<InteractionResponse> response = new PageResponse<>(
+                content,
+                interactionsPage.getTotalElements(),
+                interactionsPage.getNumber(),
+                interactionsPage.getTotalPages(),
+                interactionsPage.isLast()
+        );
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/tvl/tvlooker/api/controller/ItemController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/ItemController.java
@@ -1,6 +1,10 @@
 package org.tvl.tvlooker.api.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,8 +15,6 @@ import org.tvl.tvlooker.api.dto.mapper.ItemMapper;
 import org.tvl.tvlooker.api.dto.response.ItemResponse;
 import org.tvl.tvlooker.domain.model.dto.Item;
 import org.tvl.tvlooker.service.ItemService;
-
-import java.util.List;
 
 /**
  * REST controller for managing items.
@@ -27,15 +29,15 @@ public class ItemController {
     private final ItemService ITEM_SERVICE;
     
     /**
-     * Retrieves all items.
-     * @return A list of item responses.
+     * Retrieves all items with pagination.
+     * @param pageable Pagination configuration.
+     * @return A paginated list of item responses.
      */
     @GetMapping
-    public ResponseEntity<List<ItemResponse>> getAllItems() {
-        List<Item> items = ITEM_SERVICE.getAll();
-        List<ItemResponse> response = items.stream()
-                .map(ItemMapper::toResponse)
-                .toList();
+    public ResponseEntity<Page<ItemResponse>> getAllItems(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Item> itemsPage = ITEM_SERVICE.getAll(pageable);
+        Page<ItemResponse> response = itemsPage.map(ItemMapper::toResponse);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/tvl/tvlooker/api/controller/ListFavoriteController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/ListFavoriteController.java
@@ -2,6 +2,10 @@ package org.tvl.tvlooker.api.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,10 +20,9 @@ import org.tvl.tvlooker.api.dto.mapper.ListFavoriteMapper;
 import org.tvl.tvlooker.api.dto.request.CreateListFavoriteRequest;
 import org.tvl.tvlooker.api.dto.request.UpdateListFavoriteRequest;
 import org.tvl.tvlooker.api.dto.response.ListFavoriteResponse;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
 import org.tvl.tvlooker.domain.model.dto.ListFavorite;
 import org.tvl.tvlooker.service.ListFavoriteService;
-
-import java.util.List;
 
 /**
  * REST controller for managing favorite lists.
@@ -31,15 +34,27 @@ public class ListFavoriteController {
     private final ListFavoriteService listFavoriteService;
 
     /**
-     * Retrieves all favorite lists.
-     * @return a list of favorite list responses
+     * Retrieves all favorite lists with pagination.
+     * @param pageable pagination information
+     * @return paginated list of favorite list responses
      */
     @GetMapping
-    public ResponseEntity<List<ListFavoriteResponse>> listFavorites() {
-        List<ListFavorite> favorites = listFavoriteService.getAll();
-        return ResponseEntity.ok(favorites.stream()
+    public ResponseEntity<PageResponse<ListFavoriteResponse>> listFavorites(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<ListFavorite> favoritesPage = listFavoriteService.getAll(pageable);
+        
+        var content = favoritesPage.getContent().stream()
                 .map(ListFavoriteMapper::toResponse)
-                .toList());
+                .toList();
+        
+        PageResponse<ListFavoriteResponse> response = new PageResponse<>(
+                content,
+                favoritesPage.getTotalElements(),
+                favoritesPage.getNumber(),
+                favoritesPage.getTotalPages(),
+                favoritesPage.isLast()
+        );
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/api/controller/ReviewController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/ReviewController.java
@@ -2,6 +2,10 @@ package org.tvl.tvlooker.api.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.tvl.tvlooker.api.dto.mapper.ReviewMapper;
 import org.tvl.tvlooker.api.dto.request.CreateReviewRequest;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
 import org.tvl.tvlooker.api.dto.response.ReviewResponse;
 import org.tvl.tvlooker.domain.model.dto.Review;
 import org.tvl.tvlooker.service.ReviewService;
@@ -34,11 +39,22 @@ public class ReviewController {
      * @return a list of review responses
      */
     @GetMapping
-    public ResponseEntity<List<ReviewResponse>> getAllReviews() {
-        List<Review> reviews = reviewService.getAll();
-        return ResponseEntity.ok(reviews.stream()
+    public ResponseEntity<PageResponse<ReviewResponse>> getAllReviews(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Review> reviewsPage = reviewService.getAll(pageable);
+
+        List<ReviewResponse> content = reviewsPage.getContent().stream()
                 .map(ReviewMapper::toResponse)
-                .toList());
+                .toList();
+
+        PageResponse<ReviewResponse> response = new PageResponse<>(
+                content,
+                reviewsPage.getTotalElements(),
+                reviewsPage.getNumber(),
+                reviewsPage.getTotalPages(),
+                reviewsPage.isLast()
+        );
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/api/controller/UserController.java
+++ b/src/main/java/org/tvl/tvlooker/api/controller/UserController.java
@@ -2,6 +2,10 @@ package org.tvl.tvlooker.api.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.tvl.tvlooker.api.dto.mapper.UserMapper;
 import org.tvl.tvlooker.api.dto.request.CreateUserRequest;
 import org.tvl.tvlooker.api.dto.request.UpdateUserRequest;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
 import org.tvl.tvlooker.api.dto.response.UserResponse;
 import org.tvl.tvlooker.domain.model.dto.User;
 import org.tvl.tvlooker.service.UserService;
@@ -36,11 +41,21 @@ public class UserController {
      * @return A list of user responses.
      */
     @GetMapping
-    public ResponseEntity<List<UserResponse>> getAllUsers() {
-        List<User> users = userService.getAll();
-        List<UserResponse> response = users.stream()
+    public ResponseEntity<PageResponse<UserResponse>> getAllUsers(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<User> usersPage = userService.getAll(pageable);
+
+        List<UserResponse> content = usersPage.getContent().stream()
                 .map(UserMapper::toResponse)
                 .toList();
+
+        PageResponse<UserResponse> response = new PageResponse<>(
+                content,
+                usersPage.getTotalElements(),
+                usersPage.getNumber(),
+                usersPage.getTotalPages(),
+                usersPage.isLast()
+        );
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/tvl/tvlooker/api/dto/mapper/ListFavoriteMapper.java
+++ b/src/main/java/org/tvl/tvlooker/api/dto/mapper/ListFavoriteMapper.java
@@ -19,9 +19,11 @@ public class ListFavoriteMapper {
                 .name(listFavorite.getName())
                 .description(listFavorite.getDescription())
                 .userId(listFavorite.getUserId())
-                .items(listFavorite.getItems().stream()
-                        .map(ItemMapper::toResponse)
-                        .collect(Collectors.toSet()))
+                .items(listFavorite.getItems() == null
+                        ? null
+                        : listFavorite.getItems().stream()
+                                .map(ItemMapper::toResponse)
+                                .collect(Collectors.toSet()))
                 .build();
     }
 

--- a/src/main/java/org/tvl/tvlooker/api/dto/mapper/PageMapper.java
+++ b/src/main/java/org/tvl/tvlooker/api/dto/mapper/PageMapper.java
@@ -1,0 +1,4 @@
+package org.tvl.tvlooker.api.dto.mapper;
+
+public class PageMapper {
+}

--- a/src/main/java/org/tvl/tvlooker/api/dto/mapper/PageMapper.java
+++ b/src/main/java/org/tvl/tvlooker/api/dto/mapper/PageMapper.java
@@ -1,4 +1,19 @@
 package org.tvl.tvlooker.api.dto.mapper;
 
+import org.springframework.data.domain.Page;
+import org.tvl.tvlooker.api.dto.response.PageResponse;
+
+import java.util.List;
+
 public class PageMapper {
+
+    public static <T> PageResponse<T> toResponse(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getTotalElements(),
+                page.getNumber(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
 }

--- a/src/main/java/org/tvl/tvlooker/api/dto/mapper/PageMapper.java
+++ b/src/main/java/org/tvl/tvlooker/api/dto/mapper/PageMapper.java
@@ -3,7 +3,6 @@ package org.tvl.tvlooker.api.dto.mapper;
 import org.springframework.data.domain.Page;
 import org.tvl.tvlooker.api.dto.response.PageResponse;
 
-import java.util.List;
 
 public class PageMapper {
 

--- a/src/main/java/org/tvl/tvlooker/api/dto/response/PageResponse.java
+++ b/src/main/java/org/tvl/tvlooker/api/dto/response/PageResponse.java
@@ -1,4 +1,16 @@
 package org.tvl.tvlooker.api.dto.response;
 
-public class PageResponse {
-}
+import java.util.List;
+
+/**
+ * DTO for paginated responses.
+ *
+ * @param <T> the type of content in the page
+ */
+public record PageResponse<T>(
+    List<T> content,
+    long totalItems,
+    int actualPage,
+    int totalPages,
+    boolean isLast
+) {}

--- a/src/main/java/org/tvl/tvlooker/api/dto/response/PageResponse.java
+++ b/src/main/java/org/tvl/tvlooker/api/dto/response/PageResponse.java
@@ -1,0 +1,4 @@
+package org.tvl.tvlooker.api.dto.response;
+
+public class PageResponse {
+}

--- a/src/main/java/org/tvl/tvlooker/service/ActorService.java
+++ b/src/main/java/org/tvl/tvlooker/service/ActorService.java
@@ -1,6 +1,8 @@
 package org.tvl.tvlooker.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.tvl.tvlooker.domain.model.dto.Actor;
 import org.tvl.tvlooker.domain.exception.ActorNotFoundException;
@@ -50,6 +52,17 @@ public class ActorService {
 		return actorRepository.findAll().stream()
 				.map(ActorEntityMapper::toDomain)
 				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Get all actors with pagination.
+	 *
+	 * @param pageable pagination information
+	 * @return page of actors
+	 */
+	public Page<Actor> getAll(Pageable pageable) {
+		return actorRepository.findAll(pageable)
+				.map(ActorEntityMapper::toDomain);
 	}
 
 	/**

--- a/src/main/java/org/tvl/tvlooker/service/DirectorService.java
+++ b/src/main/java/org/tvl/tvlooker/service/DirectorService.java
@@ -1,6 +1,8 @@
 package org.tvl.tvlooker.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.tvl.tvlooker.domain.exception.DirectorNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.Director;
@@ -53,6 +55,17 @@ public class DirectorService {
 		return directorRepository.findAll().stream()
 				.map(DirectorEntityMapper::toDomain)
 				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Get all directors with pagination.
+	 *
+	 * @param pageable pagination information
+	 * @return page of directors
+	 */
+	public Page<Director> getAll(Pageable pageable) {
+		return directorRepository.findAll(pageable)
+				.map(DirectorEntityMapper::toDomain);
 	}
 
 	/**

--- a/src/main/java/org/tvl/tvlooker/service/InteractionService.java
+++ b/src/main/java/org/tvl/tvlooker/service/InteractionService.java
@@ -1,5 +1,7 @@
 package org.tvl.tvlooker.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.tvl.tvlooker.domain.model.dto.Interaction;
 import org.tvl.tvlooker.domain.exception.InteractionNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.Item;
@@ -62,6 +64,17 @@ public class InteractionService {
         return interactionRepository.findAll().stream()
                 .map(InteractionEntityMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all interactions with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of interactions
+     */
+    public Page<Interaction> getAll(Pageable pageable) {
+        return interactionRepository.findAll(pageable)
+                .map(InteractionEntityMapper::toDomain);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/service/ItemService.java
+++ b/src/main/java/org/tvl/tvlooker/service/ItemService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.function.Consumer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Service for Item entity operations.
@@ -53,6 +55,17 @@ public class ItemService {
         return itemRepository.findAll().stream()
                 .map(ItemEntityMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all items with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of items
+     */
+    public Page<Item> getAll(Pageable pageable) {
+        return itemRepository.findAll(pageable)
+                .map(ItemEntityMapper::toDomain);
     }
 
 

--- a/src/main/java/org/tvl/tvlooker/service/ListFavoriteService.java
+++ b/src/main/java/org/tvl/tvlooker/service/ListFavoriteService.java
@@ -1,6 +1,8 @@
 package org.tvl.tvlooker.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.tvl.tvlooker.domain.exception.ListFavoriteNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.ListFavorite;
@@ -57,6 +59,17 @@ public class ListFavoriteService {
         return listFavoriteRepository.findAll().stream()
                 .map(ListFavoriteEntityMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all list favorites with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of list favorites
+     */
+    public Page<ListFavorite> getAll(Pageable pageable) {
+        return listFavoriteRepository.findAll(pageable)
+                .map(ListFavoriteEntityMapper::toDomain);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/service/ReviewService.java
+++ b/src/main/java/org/tvl/tvlooker/service/ReviewService.java
@@ -1,6 +1,8 @@
 package org.tvl.tvlooker.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.tvl.tvlooker.domain.exception.ReviewNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.Item;
@@ -60,6 +62,17 @@ public class ReviewService {
         return reviewRepository.findAll().stream()
                 .map(ReviewEntityMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all reviews with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of reviews
+     */
+    public Page<Review> getAll(Pageable pageable) {
+        return reviewRepository.findAll(pageable)
+                .map(ReviewEntityMapper::toDomain);
     }
 
     /**

--- a/src/main/java/org/tvl/tvlooker/service/UserService.java
+++ b/src/main/java/org/tvl/tvlooker/service/UserService.java
@@ -1,6 +1,8 @@
 package org.tvl.tvlooker.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.tvl.tvlooker.domain.exception.UserNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.User;
@@ -54,6 +56,17 @@ public class UserService {
         return userRepository.findAll().stream()
                 .map(UserEntityMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get all users with pagination.
+     *
+     * @param pageable pagination information
+     * @return page of users
+     */
+    public Page<User> getAll(Pageable pageable) {
+        return userRepository.findAll(pageable)
+                .map(UserEntityMapper::toDomain);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,9 +22,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 
-# Pagination Configuration
-spring.data.web.pageable.max-page-size=1000
-
 # Logging Configuration
 logging.level.org.springframework=INFO
 logging.level.com.tvlooker=DEBUG
@@ -105,3 +102,10 @@ tmdb.persistence.batch-size=50
 # Maximum actors to store per item (top billed)
 # TMDB often has 100+ cast members, we only store the most important ones
 tmdb.actors.max-per-item=10
+
+# ========================================================================================
+# PAGINATION CONFIGURATION
+# ========================================================================================
+spring.data.web.pageable.max-page-size=100
+spring.data.web.pageable.default-page-size=50
+spring.data.web.pageable.one-indexed-parameters=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,9 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 
+# Pagination Configuration
+spring.data.web.pageable.max-page-size=1000
+
 # Logging Configuration
 logging.level.org.springframework=INFO
 logging.level.com.tvlooker=DEBUG

--- a/src/test/java/org/tvl/tvlooker/api/controller/ActorControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/ActorControllerTest.java
@@ -7,6 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -20,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -40,6 +46,7 @@ class ActorControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(actorController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -54,44 +61,41 @@ class ActorControllerTest {
     class GetAllActors {
 
         @Test
-        void givenActorsExist_whenGetAllActors_thenReturnsActorList() throws Exception {
+        void givenActorsExist_whenGetAllActors_thenReturnsPaginatedList() throws Exception {
             Actor secondActor = Actor.builder()
                     .id(2L)
-                    .tmdbId(200L)
-                    .name("Tom Hanks")
+                    .name("Actor Two")
+                    .tmdbId(22222L)
                     .build();
-            Actor thirdActor = Actor.builder()
-                    .id(3L)
-                    .tmdbId(300L)
-                    .name("Brad Pitt")
-                    .build();
-            List<Actor> actors = Arrays.asList(testActor, secondActor, thirdActor);
+            List<Actor> actors = Arrays.asList(testActor, secondActor);
+            Page<Actor> actorPage = new PageImpl<>(actors, PageRequest.of(0, 50), actors.size());
 
-            when(actorService.getAll()).thenReturn(actors);
+            when(actorService.getAll(any(Pageable.class))).thenReturn(actorPage);
 
-            mockMvc.perform(get("/api/v1/actors"))
+            mockMvc.perform(get("/api/v1/actors")
+                            .param("page", "0")
+                            .param("size", "50"))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(3)))
-                    .andExpect(jsonPath("$[0].id", is(1)))
-                    .andExpect(jsonPath("$[0].name", is("Leonardo DiCaprio")))
-                    .andExpect(jsonPath("$[0].tmdbId", is(100)))
-                    .andExpect(jsonPath("$[1].name", is("Tom Hanks")))
-                    .andExpect(jsonPath("$[2].name", is("Brad Pitt")));
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
 
-            verify(actorService, times(1)).getAll();
+            verify(actorService, times(1)).getAll(any(Pageable.class));
         }
 
         @Test
-        void givenNoActors_whenGetAllActors_thenReturnsEmptyList() throws Exception {
-            when(actorService.getAll()).thenReturn(Collections.emptyList());
+        void givenNoActors_whenGetAllActors_thenReturnsEmptyPage() throws Exception {
+            Page<Actor> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(actorService.getAll(any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/actors"))
                     .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
 
-            verify(actorService, times(1)).getAll();
+            verify(actorService, times(1)).getAll(any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/api/controller/DirectorControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/DirectorControllerTest.java
@@ -7,6 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -40,6 +45,7 @@ class DirectorControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(directorController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -54,44 +60,41 @@ class DirectorControllerTest {
     class GetAllDirectors {
 
         @Test
-        void givenDirectorsExist_whenGetAllDirectors_thenReturnsDirectorList() throws Exception {
+        void givenDirectorsExist_whenGetAllDirectors_thenReturnsPaginatedList() throws Exception {
             Director secondDirector = Director.builder()
                     .id(2L)
                     .tmdbId(200L)
                     .name("Steven Spielberg")
                     .build();
-            Director thirdDirector = Director.builder()
-                    .id(3L)
-                    .tmdbId(300L)
-                    .name("Quentin Tarantino")
-                    .build();
-            List<Director> directors = Arrays.asList(testDirector, secondDirector, thirdDirector);
+            List<Director> directors = Arrays.asList(testDirector, secondDirector);
+            Page<Director> directorPage = new PageImpl<>(directors, PageRequest.of(0, 50), directors.size());
 
-            when(directorService.getAll()).thenReturn(directors);
+            when(directorService.getAll(org.mockito.ArgumentMatchers.any(Pageable.class))).thenReturn(directorPage);
 
-            mockMvc.perform(get("/api/v1/directors"))
+            mockMvc.perform(get("/api/v1/directors")
+                            .param("page", "0")
+                            .param("size", "50"))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(3)))
-                    .andExpect(jsonPath("$[0].id", is(1)))
-                    .andExpect(jsonPath("$[0].name", is("Christopher Nolan")))
-                    .andExpect(jsonPath("$[0].tmdbId", is(100)))
-                    .andExpect(jsonPath("$[1].name", is("Steven Spielberg")))
-                    .andExpect(jsonPath("$[2].name", is("Quentin Tarantino")));
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
 
-            verify(directorService, times(1)).getAll();
+            verify(directorService, times(1)).getAll(org.mockito.ArgumentMatchers.any(Pageable.class));
         }
 
         @Test
-        void givenNoDirectors_whenGetAllDirectors_thenReturnsEmptyList() throws Exception {
-            when(directorService.getAll()).thenReturn(Collections.emptyList());
+        void givenNoDirectors_whenGetAllDirectors_thenReturnsEmptyPage() throws Exception {
+            Page<Director> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(directorService.getAll(org.mockito.ArgumentMatchers.any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/directors"))
                     .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
 
-            verify(directorService, times(1)).getAll();
+            verify(directorService, times(1)).getAll(org.mockito.ArgumentMatchers.any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/api/controller/InteractionControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/InteractionControllerTest.java
@@ -8,6 +8,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -19,7 +24,9 @@ import org.tvl.tvlooker.service.InteractionService;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.*;
@@ -47,6 +54,7 @@ class InteractionControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(interactionController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
         objectMapper = new ObjectMapper();
@@ -66,15 +74,42 @@ class InteractionControllerTest {
     class GetAllInteractions {
 
         @Test
-        void givenNoInteractions_whenGetAllInteractions_thenReturnsEmptyList() throws Exception {
-            when(interactionService.getAll()).thenReturn(Collections.emptyList());
+        void givenInteractionsExist_whenGetAllInteractions_thenReturnsPaginatedList() throws Exception {
+            Interaction secondInteraction = Interaction.builder()
+                    .id(2L)
+                    .userId(testUserId)
+                    .itemId(2L)
+                    .interactionType(InteractionType.VIEW)
+                    .build();
+            List<Interaction> interactions = Arrays.asList(testInteraction, secondInteraction);
+            Page<Interaction> interactionPage = new PageImpl<>(interactions, PageRequest.of(0, 50), interactions.size());
+
+            when(interactionService.getAll(any(Pageable.class))).thenReturn(interactionPage);
+
+            mockMvc.perform(get("/api/v1/interactions")
+                            .param("page", "0")
+                            .param("size", "50"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
+
+            verify(interactionService, times(1)).getAll(any(Pageable.class));
+        }
+
+        @Test
+        void givenNoInteractions_whenGetAllInteractions_thenReturnsEmptyPage() throws Exception {
+            Page<Interaction> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(interactionService.getAll(any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/interactions"))
                     .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
 
-            verify(interactionService, times(1)).getAll();
+            verify(interactionService, times(1)).getAll(any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/api/controller/ItemControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/ItemControllerTest.java
@@ -7,6 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -44,6 +50,7 @@ class ItemControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(itemController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -66,7 +73,7 @@ class ItemControllerTest {
     class GetAllItems {
 
         @Test
-        void givenItemsExist_whenGetAllItems_thenReturnsItemList() throws Exception {
+        void givenItemsExist_whenGetAllItems_thenReturnsPaginatedList() throws Exception {
             Item secondItem = Item.builder()
                     .id(2L)
                     .title("Test TV Show")
@@ -78,62 +85,42 @@ class ItemControllerTest {
                     .tmdbId(67890L)
                     .genres(new HashSet<>())
                     .directors(new HashSet<>())
-                    .actorsInItem(new HashSet<>())         .build();
-            List<Item> items = Arrays.asList(testItem, secondItem);
-
-            when(itemService.getAll()).thenReturn(items);
-
-            mockMvc.perform(get("/api/v1/items"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(2)))
-                    .andExpect(jsonPath("$[0].id", is(1)))
-                    .andExpect(jsonPath("$[0].title", is("Test Movie")))
-                    .andExpect(jsonPath("$[0].overview", is("This is a test movie overview")))
-                    .andExpect(jsonPath("$[0].tmdbType", is("MOVIE")))
-                    .andExpect(jsonPath("$[1].title", is("Test TV Show")));
-
-            verify(itemService, times(1)).getAll();
-        }
-
-        @Test
-        void givenNoItems_whenGetAllItems_thenReturnsEmptyList() throws Exception {
-            when(itemService.getAll()).thenReturn(Collections.emptyList());
-
-            mockMvc.perform(get("/api/v1/items"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
-
-            verify(itemService, times(1)).getAll();
-        }
-
-        @Test
-        void givenItemsWithNullReleaseDate_whenGetAllItems_thenReturnsItemList() throws Exception {
-            Item itemWithNullDate = Item.builder()
-                    .id(3L)
-                    .title("Movie Without Date")
-                    .overview("No release date")
-                    .releaseDate(null)
-                    .popularity(new BigDecimal("5.0"))
-                    .voteAverage(new BigDecimal("6.0"))
-                    .tmdbType(TmdbType.MOVIE)
-                    .tmdbId(11111L)
-                    .genres(new HashSet<>())
-                    .directors(new HashSet<>())
                     .actorsInItem(new HashSet<>())
                     .build();
+            List<Item> items = Arrays.asList(testItem, secondItem);
+            Page<Item> itemPage = new PageImpl<>(items, PageRequest.of(0, 50), items.size());
 
-            when(itemService.getAll()).thenReturn(Collections.singletonList(itemWithNullDate));
+            when(itemService.getAll(org.mockito.ArgumentMatchers.any(Pageable.class))).thenReturn(itemPage);
+
+            mockMvc.perform(get("/api/v1/items")
+                            .param("page", "0")
+                            .param("size", "50"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.content[0].title", is("Test Movie")))
+                    .andExpect(jsonPath("$.content[1].title", is("Test TV Show")))
+                    .andExpect(jsonPath("$.totalElements", is(2)))
+                    .andExpect(jsonPath("$.totalPages", is(1)))
+                    .andExpect(jsonPath("$.size", is(50)))
+                    .andExpect(jsonPath("$.number", is(0)));
+
+            verify(itemService, times(1)).getAll(org.mockito.ArgumentMatchers.any(Pageable.class));
+        }
+
+        @Test
+        void givenNoItems_whenGetAllItems_thenReturnsEmptyPage() throws Exception {
+            Page<Item> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(itemService.getAll(org.mockito.ArgumentMatchers.any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/items"))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(1)))
-                    .andExpect(jsonPath("$[0].title", is("Movie Without Date")))
-                    .andExpect(jsonPath("$[0].releaseDate").doesNotExist());
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalElements", is(0)));
 
-            verify(itemService, times(1)).getAll();
+            verify(itemService, times(1)).getAll(org.mockito.ArgumentMatchers.any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/api/controller/ListFavoriteControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/ListFavoriteControllerTest.java
@@ -16,7 +16,9 @@ import org.tvl.tvlooker.domain.exception.ListFavoriteNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.ListFavorite;
 import org.tvl.tvlooker.service.ListFavoriteService;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.*;
@@ -25,6 +27,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 
 @ExtendWith(MockitoExtension.class)
 class ListFavoriteControllerTest {
@@ -39,31 +47,66 @@ class ListFavoriteControllerTest {
     private ObjectMapper objectMapper;
 
     private UUID testUserId;
+    private ListFavorite testListFavorite;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(listFavoriteController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
         objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
 
         testUserId = UUID.randomUUID();
+
+        testListFavorite = ListFavorite.builder()
+                .id(1L)
+                .userId(testUserId)
+                .name("My Favorites")
+                .description("My favorite movies")
+                .build();
     }
 
     @Nested
     class ListFavorites {
 
         @Test
-        void givenFavoritesExist_whenListFavorites_thenReturnsFavoriteLists() throws Exception {
-            when(listFavoriteService.getAll()).thenReturn(Collections.emptyList());
+        void givenListFavoritesExist_whenListFavorites_thenReturnsPaginatedList() throws Exception {
+            ListFavorite secondList = ListFavorite.builder()
+                    .id(2L)
+                    .userId(testUserId)
+                    .name("My Second List")
+                    .build();
+            List<ListFavorite> favorites = Arrays.asList(testListFavorite, secondList);
+            Page<ListFavorite> favoritesPage = new PageImpl<>(favorites, PageRequest.of(0, 50), favorites.size());
+
+            when(listFavoriteService.getAll(any(Pageable.class))).thenReturn(favoritesPage);
+
+            mockMvc.perform(get("/api/v1/lists")
+                            .param("page", "0")
+                            .param("size", "50"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
+
+            verify(listFavoriteService, times(1)).getAll(any(Pageable.class));
+        }
+
+        @Test
+        void givenNoListFavorites_whenListFavorites_thenReturnsEmptyPage() throws Exception {
+            Page<ListFavorite> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(listFavoriteService.getAll(any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/lists"))
                     .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
 
-            verify(listFavoriteService, times(1)).getAll();
+            verify(listFavoriteService, times(1)).getAll(any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/api/controller/ReviewControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/ReviewControllerTest.java
@@ -8,6 +8,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -18,7 +23,9 @@ import org.tvl.tvlooker.service.ReviewService;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.*;
@@ -46,6 +53,7 @@ class ReviewControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(reviewController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
         objectMapper = new ObjectMapper();
@@ -66,15 +74,44 @@ class ReviewControllerTest {
     class GetAllReviews {
 
         @Test
-        void givenNoReviews_whenGetAllReviews_thenReturnsEmptyList() throws Exception {
-            when(reviewService.getAll()).thenReturn(Collections.emptyList());
+        void givenReviewsExist_whenGetAllReviews_thenReturnsPaginatedList() throws Exception {
+            UUID userId2 = UUID.randomUUID();
+            Review secondReview = Review.builder()
+                    .id(2L)
+                    .userId(userId2)
+                    .itemId(2L)
+                    .score(4)
+                    .reviewText("Great show!")
+                    .build();
+            List<Review> reviews = Arrays.asList(testReview, secondReview);
+            Page<Review> reviewsPage = new PageImpl<>(reviews, PageRequest.of(0, 50), reviews.size());
+
+            when(reviewService.getAll(any(Pageable.class))).thenReturn(reviewsPage);
+
+            mockMvc.perform(get("/api/v1/reviews")
+                            .param("page", "0")
+                            .param("size", "50"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(1)))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
+
+            verify(reviewService, times(1)).getAll(any(Pageable.class));
+        }
+
+        @Test
+        void givenNoReviews_whenGetAllReviews_thenReturnsEmptyPage() throws Exception {
+            Page<Review> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(reviewService.getAll(any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/reviews"))
                     .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
 
-            verify(reviewService, times(1)).getAll();
+            verify(reviewService, times(1)).getAll(any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/api/controller/UserControllerTest.java
+++ b/src/test/java/org/tvl/tvlooker/api/controller/UserControllerTest.java
@@ -8,6 +8,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -48,6 +53,7 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(userController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
         objectMapper = new ObjectMapper();
@@ -68,40 +74,41 @@ class UserControllerTest {
     class GetAllUsers {
 
         @Test
-        void givenUsersExist_whenGetAllUsers_thenReturnsUserList() throws Exception {
+        void givenUsersExist_whenGetAllUsers_thenReturnsPaginatedList() throws Exception {
             User secondUser = User.builder()
-                    .id(UUID.randomUUID())
-                    .username("anotheruser")
-                    .email("another@example.com")
-                    .name("Another User")
-                    .password("pass456")
-                    .createdAt(Timestamp.from(Instant.now()))
+                    .id(testUserId)
+                    .username("seconduser")
+                    .email("second@test.com")
                     .build();
             List<User> users = Arrays.asList(testUser, secondUser);
+            Page<User> usersPage = new PageImpl<>(users, PageRequest.of(0, 50), users.size());
 
-            when(userService.getAll()).thenReturn(users);
+            when(userService.getAll(any(Pageable.class))).thenReturn(usersPage);
 
-            mockMvc.perform(get("/api/v1/users"))
+            mockMvc.perform(get("/api/v1/users")
+                            .param("page", "0")
+                            .param("size", "50"))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(2)))
-                    .andExpect(jsonPath("$[0].username", is("testuser")))
-                    .andExpect(jsonPath("$[0].email", is("test@example.com")))
-                    .andExpect(jsonPath("$[1].username", is("anotheruser")));
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(testUserId.toString())))
+                    .andExpect(jsonPath("$.totalItems", is(2)))
+                    .andExpect(jsonPath("$.actualPage", is(0)));
 
-            verify(userService, times(1)).getAll();
+            verify(userService, times(1)).getAll(any(Pageable.class));
         }
 
         @Test
-        void givenNoUsers_whenGetAllUsers_thenReturnsEmptyList() throws Exception {
-            when(userService.getAll()).thenReturn(Collections.emptyList());
+        void givenNoUsers_whenGetAllUsers_thenReturnsEmptyPage() throws Exception {
+            Page<User> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 50), 0);
+            when(userService.getAll(any(Pageable.class))).thenReturn(emptyPage);
 
             mockMvc.perform(get("/api/v1/users"))
                     .andExpect(status().isOk())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$", hasSize(0)));
+                    .andExpect(jsonPath("$.content", hasSize(0)))
+                    .andExpect(jsonPath("$.totalItems", is(0)));
 
-            verify(userService, times(1)).getAll();
+            verify(userService, times(1)).getAll(any(Pageable.class));
         }
     }
 

--- a/src/test/java/org/tvl/tvlooker/service/ActorServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/ActorServiceTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.tvl.tvlooker.domain.exception.ActorNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.Actor;
 import org.tvl.tvlooker.domain.model.entity.ActorEntity;
@@ -204,5 +208,34 @@ class ActorServiceTest {
                 .hasMessageContaining("Actor not found: " + nonExistentId);
         verify(actorRepository, times(1)).existsById(nonExistentId);
         verify(actorRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("getAll with Pageable - should return page of actors")
+    void givenPageable_whenGetAll_thenReturnsPageOfActors() {
+        Pageable pageable = PageRequest.of(0, 10);
+        ActorEntity actorEntity2 = ActorEntity.builder()
+                .id(2L)
+                .tmdbId(31L)
+                .name("Tom Hanks")
+                .build();
+        List<ActorEntity> entities = List.of(testActorEntity, actorEntity2);
+        Page<ActorEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+
+        when(actorRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Actor> result = actorService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(actorRepository, times(1)).findAll(pageable);
+    }
+
+    private ActorEntity createActorEntityWithId(Long id) {
+        return ActorEntity.builder()
+                .id(id)
+                .tmdbId(100L + id)
+                .name("Actor " + id)
+                .build();
     }
 }

--- a/src/test/java/org/tvl/tvlooker/service/DirectorServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/DirectorServiceTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.tvl.tvlooker.domain.exception.DirectorNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.Director;
 import org.tvl.tvlooker.domain.model.entity.DirectorEntity;
@@ -204,5 +208,26 @@ class DirectorServiceTest {
                 .hasMessageContaining("Director not found: " + nonExistentId);
         verify(directorRepository, times(1)).existsById(nonExistentId);
         verify(directorRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("getAll with Pageable - should return page of directors")
+    void givenPageable_whenGetAll_thenReturnsPageOfDirectors() {
+        Pageable pageable = PageRequest.of(0, 10);
+        DirectorEntity directorEntity2 = DirectorEntity.builder()
+                .id(2L)
+                .tmdbId(488L)
+                .name("Steven Spielberg")
+                .build();
+        List<DirectorEntity> entities = List.of(testDirectorEntity, directorEntity2);
+        Page<DirectorEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+
+        when(directorRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Director> result = directorService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(directorRepository, times(1)).findAll(pageable);
     }
 }

--- a/src/test/java/org/tvl/tvlooker/service/InteractionServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/InteractionServiceTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.tvl.tvlooker.domain.exception.InteractionNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.Interaction;
 import org.tvl.tvlooker.domain.model.dto.Item;
@@ -168,6 +172,31 @@ class InteractionServiceTest {
         assertThat(result).isNotNull();
         assertThat(result).isEmpty();
         verify(interactionRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("getAll with Pageable - should return page of interactions")
+    void givenPageable_whenGetAll_thenReturnsPageOfInteractions() {
+        Pageable pageable = PageRequest.of(0, 10);
+        List<InteractionEntity> entities = List.of(testInteractionEntity, createInteractionEntityWithId(2L));
+        Page<InteractionEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+
+        when(interactionRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Interaction> result = interactionService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2L);
+        verify(interactionRepository, times(1)).findAll(pageable);
+    }
+
+    private InteractionEntity createInteractionEntityWithId(Long id) {
+        return InteractionEntity.builder()
+                .id(id)
+                .user(UserEntity.builder().id(UUID.randomUUID()).username("user2").email("user2@test.com").name("User 2").build())
+                .item(ItemEntity.builder().id(2L).title("Movie 2").overview("Overview 2").build())
+                .interactionType(InteractionType.VIEW)
+                .build();
     }
 
     @Test

--- a/src/test/java/org/tvl/tvlooker/service/ItemServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/ItemServiceTest.java
@@ -16,6 +16,10 @@ import org.tvl.tvlooker.persistence.repository.ItemRepository;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -225,5 +229,31 @@ class ItemServiceTest {
                 .hasMessageContaining("Item not found: " + nonExistentId);
         verify(itemRepository, times(1)).existsById(nonExistentId);
         verify(itemRepository, never()).deleteById(any(Long.class));
+    }
+
+    @Test
+    @DisplayName("getAll with Pageable - should return page of items")
+    void givenPageable_whenGetAll_thenReturnsPageOfItems() {
+        Pageable pageable = PageRequest.of(0, 10);
+        ItemEntity itemEntity2 = ItemEntity.builder()
+                .id(2L)
+                .title("Test Title 2")
+                .overview("Test overview 2")
+                .popularity(BigDecimal.valueOf(7.5))
+                .tmdbType(TmdbType.MOVIE)
+                .tmdbId(551L)
+                .build();
+        List<ItemEntity> entities = List.of(testItemEntity, itemEntity2);
+        Page<ItemEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+        
+        when(itemRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Item> result = itemService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("Test Movie");
+        verify(itemRepository, times(1)).findAll(pageable);
     }
 }

--- a/src/test/java/org/tvl/tvlooker/service/ListFavoriteServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/ListFavoriteServiceTest.java
@@ -22,6 +22,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ListFavoriteService Unit Tests")
 class ListFavoriteServiceTest {
@@ -238,7 +243,7 @@ class ListFavoriteServiceTest {
         verify(listFavoriteRepository, times(1)).deleteById(testListId);
     }
 
-    @Test
+@Test
     @DisplayName("delete - should throw ListFavoriteNotFoundException when list does not exist")
     void deleteById_shouldThrowListFavoriteNotFoundException_whenListDoesNotExist() {
         Long nonExistentId = 999L;
@@ -249,5 +254,27 @@ class ListFavoriteServiceTest {
                 .hasMessageContaining("ListFavorite not found: " + nonExistentId);
         verify(listFavoriteRepository, times(1)).existsById(nonExistentId);
         verify(listFavoriteRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("getAll with Pageable - should return page of list favorites")
+    void givenPageable_whenGetAll_thenReturnsPageOfListFavorites() {
+        Pageable pageable = PageRequest.of(0, 10);
+        ListFavoriteEntity list2 = ListFavoriteEntity.builder()
+                .id(2L)
+                .user(UserEntity.builder().id(testUserId).username("testuser").email("test@test.com").name("Test User").build())
+                .name("Watchlist")
+                .description("Movies to watch")
+                .build();
+        List<ListFavoriteEntity> entities = List.of(testListEntity, list2);
+        Page<ListFavoriteEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+        
+        when(listFavoriteRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<ListFavorite> result = listFavoriteService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+verify(listFavoriteRepository, times(1)).findAll(pageable);
     }
 }

--- a/src/test/java/org/tvl/tvlooker/service/ReviewServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/ReviewServiceTest.java
@@ -20,6 +20,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -254,5 +259,29 @@ class ReviewServiceTest {
                 .hasMessageContaining("Review not found: " + nonExistentId);
         verify(reviewRepository, times(1)).existsById(nonExistentId);
         verify(reviewRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("getAll - with pagination should return page of reviews")
+    void givenPageable_whenGetAll_thenReturnsPageOfReviews() {
+        Pageable pageable = PageRequest.of(0, 10);
+        UUID userId2 = UUID.randomUUID();
+        ReviewEntity reviewEntity2 = ReviewEntity.builder()
+                .id(2L)
+                .user(UserEntity.builder().id(userId2).username("user2").email("user2@test.com").name("User 2").build())
+                .item(ItemEntity.builder().id(2L).title("Movie 2").overview("Overview 2").build())
+                .reviewText("Excellent!")
+                .score(9)
+                .build();
+        List<ReviewEntity> entities = List.of(testReviewEntity, reviewEntity2);
+        Page<ReviewEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+
+        when(reviewRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<Review> result = reviewService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(reviewRepository, times(1)).findAll(pageable);
     }
 }

--- a/src/test/java/org/tvl/tvlooker/service/UserServiceTest.java
+++ b/src/test/java/org/tvl/tvlooker/service/UserServiceTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.tvl.tvlooker.domain.exception.UserNotFoundException;
 import org.tvl.tvlooker.domain.model.dto.User;
 import org.tvl.tvlooker.domain.model.entity.UserEntity;
@@ -217,5 +221,28 @@ class UserServiceTest {
                 .hasMessageContaining("User not found with id: " + nonExistentId);
         verify(userRepository, times(1)).existsById(nonExistentId);
         verify(userRepository, never()).deleteById(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("getAll with Pageable - should return page of users")
+    void givenPageable_whenGetAll_thenReturnsPageOfUsers() {
+        Pageable pageable = PageRequest.of(0, 10);
+        UserEntity user2Entity = UserEntity.builder()
+                .id(testUserId)
+                .username("seconduser")
+                .email("second@test.com")
+                .name("Second User")
+                .password("password456")
+                .build();
+        List<UserEntity> entities = List.of(testUserEntity, user2Entity);
+        Page<UserEntity> entityPage = new PageImpl<>(entities, pageable, 2);
+
+        when(userRepository.findAll(pageable)).thenReturn(entityPage);
+
+        Page<User> result = userService.getAll(pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(userRepository, times(1)).findAll(pageable);
     }
 }


### PR DESCRIPTION
## 📌 Descripción
Se ha implementado una estrategia de paginación basada en offset (limit/offset) para todos los endpoints `getAll` en los controladores con gran volumen de datos (Item, Actor, Director, Interaction, ListFavorite, Review, User), a excepción de Genre dado que la cantidad de géneros es aprox 26.

Se creó un wrapper `PageResponse<T>` genérico para retornar la información paginada (contenido, total de elementos, página actual, total de páginas, bandera isLast). 
Adicionalmente se configuró globalmente en `application.properties` un tamaño máximo de página (`spring.data.web.pageable.max-page-size=100`) para evitar consultas excesivas en caso de errores en frontend.

## 🧪 Tipo de cambio
- [x] Nueva funcionalidad
- [ ] Corrección
- [x] Refactor
- [x] Tests
- [x] Documentación
- [x] Configuración / CI

## ✅ Checklist
- [x] El código compila
- [x] Los tests pasan
- [x] Se ejecutó `mvn clean verify`
- [x] Cumple Checkstyle y PMD

## 🔗 Issue relacionado
Closes #54